### PR TITLE
feat: add nested list support with NestUL, NestOL, and hierarchical numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,87 @@ fmt.Println(ty.OL("First", "Second", "Third"))
 
 `UL` uses a bullet character (default `•`). `OL` uses `1.`, `2.`, `3.` markers.
 
+### Nested lists
+
+`NestUL` and `NestOL` render hierarchical lists with configurable indentation, bullet cycling, and mixed nesting.
+
+**Constructors:**
+
+| Function                                | Description                         |
+| --------------------------------------- | ----------------------------------- |
+| `Item(text)`                            | Leaf item (no children)             |
+| `Items(texts...)`                       | Batch-convert strings to leaf items |
+| `ItemWithChildren(text, children...)`   | Item with unordered sub-list        |
+| `ItemWithOLChildren(text, children...)` | Item with ordered sub-list          |
+
+```go
+// Nested unordered list with mixed sub-lists
+fmt.Println(ty.NestUL(
+    herald.Item("Fruits"),
+    herald.ItemWithChildren("Vegetables",
+        herald.Item("Carrots"),
+        herald.Item("Peas"),
+    ),
+    herald.ItemWithOLChildren("Ranked Desserts",
+        herald.Item("Ice cream"),
+        herald.Item("Cake"),
+    ),
+))
+```
+
+```
+• Fruits
+• Vegetables
+  ◦ Carrots
+  ◦ Peas
+• Ranked Desserts
+  1. Ice cream
+  2. Cake
+```
+
+```go
+// Nested ordered list
+fmt.Println(ty.NestOL(
+    herald.Item("Introduction"),
+    herald.ItemWithOLChildren("Main Topics",
+        herald.Item("Architecture"),
+        herald.Item("Design"),
+    ),
+    herald.Item("Conclusion"),
+))
+```
+
+```
+1. Introduction
+2. Main Topics
+  1. Architecture
+  2. Design
+3. Conclusion
+```
+
+Enable `WithHierarchicalNumbers(true)` for outline-style numbering (`2.1.`, `2.2.`):
+
+```go
+ty := herald.New(herald.WithHierarchicalNumbers(true))
+
+fmt.Println(ty.NestOL(
+    herald.Item("Introduction"),
+    herald.ItemWithOLChildren("Main Topics",
+        herald.Item("Architecture"),
+        herald.Item("Design"),
+    ),
+    herald.Item("Conclusion"),
+))
+```
+
+```
+1. Introduction
+2. Main Topics
+  2.1. Architecture
+  2.2. Design
+3. Conclusion
+```
+
 ### Inline styles
 
 | Method                | Renders as                                                                  |
@@ -198,16 +279,19 @@ ty := herald.New(
 
 **Token options** — each accepts a `string` or `int`:
 
-| Option                   | Default | Description                         |
-| ------------------------ | ------- | ----------------------------------- |
-| `WithH1UnderlineChar(c)` | `═`     | Underline character for H1          |
-| `WithH2UnderlineChar(c)` | `─`     | Underline character for H2          |
-| `WithH3UnderlineChar(c)` | `·`     | Underline character for H3          |
-| `WithHeadingBarChar(c)`  | `▎`     | Bar prefix character for H4–H6      |
-| `WithBulletChar(c)`      | `•`     | Bullet character for `UL`           |
-| `WithHRChar(c)`          | `─`     | Character repeated for `HR`         |
-| `WithHRWidth(w)`         | `40`    | Width of `HR` in characters         |
-| `WithBlockquoteBar(c)`   | `│`     | Left bar character for `Blockquote` |
+| Option                         | Default            | Description                                           |
+| ------------------------------ | ------------------ | ----------------------------------------------------- |
+| `WithH1UnderlineChar(c)`       | `═`                | Underline character for H1                            |
+| `WithH2UnderlineChar(c)`       | `─`                | Underline character for H2                            |
+| `WithH3UnderlineChar(c)`       | `·`                | Underline character for H3                            |
+| `WithHeadingBarChar(c)`        | `▎`                | Bar prefix character for H4–H6                        |
+| `WithBulletChar(c)`            | `•`                | Bullet character for `UL`                             |
+| `WithNestedBulletChars(chars)` | `•`, `◦`, `▪`, `▹` | Bullet characters cycling per depth for `NestUL`      |
+| `WithListIndent(n)`            | `2`                | Spaces per nesting level for `NestUL`/`NestOL`        |
+| `WithHierarchicalNumbers(b)`   | `false`            | Outline-style numbering for nested `OL` (e.g. `2.1.`) |
+| `WithHRChar(c)`                | `─`                | Character repeated for `HR`                           |
+| `WithHRWidth(w)`               | `40`               | Width of `HR` in characters                           |
+| `WithBlockquoteBar(c)`         | `│`                | Left bar character for `Blockquote`                   |
 
 ### Code formatting
 
@@ -349,8 +433,9 @@ Runnable examples are in the [`examples/`](examples/) directory:
 | Example                                                        | Description                                                                                | Run                                                |
 | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------- |
 | [basic](examples/basic/)                                       | All elements with the default Rose Pine theme                                              | `go run ./examples/basic/`                         |
+| [lists](examples/lists/)                                       | Flat, nested, mixed, and hierarchical lists                                                | `go run ./examples/lists/`                         |
 | [custom-options](examples/custom-options/)                     | Override styles, decoration chars, and tokens via functional options                       | `go run ./examples/custom-options/`                |
-| [palette](examples/palette/)                                   | Generate a full theme from 8 colors using `ColorPalette`                                   | `go run ./examples/palette/`                       |
+| [palette](examples/palette/)                                   | Generate a full theme from 9 colors using `ColorPalette`                                   | `go run ./examples/palette/`                       |
 | [builtin-themes](examples/builtin-themes/)                     | Built-in themes (Dracula, Catppuccin, Base16, Charm) matching huh                          | `go run ./examples/builtin-themes/`                |
 | [catppuccin-theme](examples/catppuccin-theme/)                 | Build a full theme from the [Catppuccin](https://catppuccin.com) palette (separate module) | `cd examples/catppuccin-theme && go run .`         |
 | [syntax-highlighting](examples/syntax-highlighting/)           | Plug in chroma for syntax-highlighted code blocks (separate module)                        | `cd examples/syntax-highlighting && go run .`      |

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -38,6 +38,32 @@ func main() {
 	fmt.Println(ty.OL("First item", "Second item", "Third item"))
 	fmt.Println()
 
+	// Nested lists
+	fmt.Println(ty.H3("Nested Unordered List"))
+	fmt.Println(ty.NestUL(
+		herald.Item("Fruits"),
+		herald.ItemWithChildren("Vegetables",
+			herald.Item("Carrots"),
+			herald.Item("Peas"),
+		),
+		herald.ItemWithOLChildren("Ranked Desserts",
+			herald.Item("Ice cream"),
+			herald.Item("Cake"),
+		),
+	))
+	fmt.Println()
+
+	fmt.Println(ty.H3("Nested Ordered List"))
+	fmt.Println(ty.NestOL(
+		herald.Item("Introduction"),
+		herald.ItemWithChildren("Main Topics",
+			herald.Item("Architecture"),
+			herald.Item("Design"),
+		),
+		herald.Item("Conclusion"),
+	))
+	fmt.Println()
+
 	// Inline styles
 	fmt.Println(ty.H3("Inline Styles"))
 	fmt.Println(ty.Bold("Bold text"))

--- a/examples/lists/main.go
+++ b/examples/lists/main.go
@@ -1,0 +1,133 @@
+// Demonstrates flat lists, nested lists, mixed nesting, and hierarchical numbering.
+// Run: go run ./examples/lists/
+package main
+
+import (
+	"fmt"
+
+	"github.com/indaco/herald"
+)
+
+func main() {
+	ty := herald.New()
+
+	// --- Flat lists (UL / OL) ---
+
+	fmt.Println(ty.H2("Flat Lists"))
+
+	fmt.Println(ty.H3("Unordered List"))
+	fmt.Println(ty.UL("Apples", "Bananas", "Cherries"))
+	fmt.Println()
+
+	fmt.Println(ty.H3("Ordered List"))
+	fmt.Println(ty.OL("First item", "Second item", "Third item"))
+	fmt.Println()
+
+	// --- Nested unordered list ---
+
+	fmt.Println(ty.H2("Nested Lists"))
+
+	fmt.Println(ty.H3("Nested Unordered List"))
+	fmt.Println(ty.NestUL(
+		herald.Item("Fruits"),
+		herald.ItemWithChildren("Vegetables",
+			herald.Item("Carrots"),
+			herald.Item("Peas"),
+			herald.ItemWithChildren("Leafy Greens",
+				herald.Item("Spinach"),
+				herald.Item("Kale"),
+			),
+		),
+		herald.Item("Grains"),
+	))
+	fmt.Println()
+
+	// --- Nested ordered list ---
+
+	fmt.Println(ty.H3("Nested Ordered List"))
+	fmt.Println(ty.NestOL(
+		herald.Item("Introduction"),
+		herald.ItemWithOLChildren("Main Topics",
+			herald.Item("Architecture"),
+			herald.Item("Design"),
+		),
+		herald.Item("Conclusion"),
+	))
+	fmt.Println()
+
+	// --- Mixed nesting (OL children inside UL) ---
+
+	fmt.Println(ty.H3("Mixed Nesting — Ordered inside Unordered"))
+	fmt.Println(ty.NestUL(
+		herald.Item("Overview"),
+		herald.ItemWithOLChildren("Ranked Desserts",
+			herald.Item("Ice cream"),
+			herald.Item("Cake"),
+			herald.Item("Pie"),
+		),
+		herald.Item("Summary"),
+	))
+	fmt.Println()
+
+	// --- Mixed nesting (UL children inside OL) ---
+
+	fmt.Println(ty.H3("Mixed Nesting — Unordered inside Ordered"))
+	fmt.Println(ty.NestOL(
+		herald.Item("Planning"),
+		herald.ItemWithChildren("Resources",
+			herald.Item("Books"),
+			herald.Item("Articles"),
+		),
+		herald.Item("Execution"),
+	))
+	fmt.Println()
+
+	// --- Batch items with Items() ---
+
+	fmt.Println(ty.H3("Batch Items with Items()"))
+	fmt.Println(ty.NestUL(herald.Items("Alpha", "Beta", "Gamma")...))
+	fmt.Println()
+
+	// --- Hierarchical numbering ---
+
+	fmt.Println(ty.H2("Hierarchical Numbering"))
+
+	tyHier := herald.New(herald.WithHierarchicalNumbers(true))
+
+	fmt.Println(tyHier.H3("Outline-style Ordered List"))
+	fmt.Println(tyHier.NestOL(
+		herald.Item("Introduction"),
+		herald.ItemWithOLChildren("Main Topics",
+			herald.Item("Architecture"),
+			herald.ItemWithOLChildren("Design",
+				herald.Item("UI"),
+				herald.Item("API"),
+			),
+		),
+		herald.Item("Conclusion"),
+	))
+	fmt.Println()
+
+	// --- Custom options ---
+
+	fmt.Println(ty.H2("Custom Options"))
+
+	tyCustom := herald.New(
+		herald.WithNestedBulletChars([]string{"*", "o", "-", ">"}),
+		herald.WithListIndent(4),
+	)
+
+	fmt.Println(tyCustom.H3("Custom Bullets and Indent"))
+	fmt.Println(tyCustom.NestUL(
+		herald.Item("Level 0"),
+		herald.ItemWithChildren("Level 0 with children",
+			herald.Item("Level 1"),
+			herald.ItemWithChildren("Level 1 with children",
+				herald.Item("Level 2"),
+				herald.ItemWithChildren("Level 2 with children",
+					herald.Item("Level 3"),
+				),
+			),
+		),
+	))
+}

--- a/list.go
+++ b/list.go
@@ -1,0 +1,45 @@
+package herald
+
+// ListKind determines whether a list is rendered as unordered or ordered.
+type ListKind int
+
+const (
+	// Unordered renders list items with bullet characters.
+	Unordered ListKind = iota
+	// Ordered renders list items with sequential numbers.
+	Ordered
+)
+
+// ListItem represents a single entry in a nested list. It may contain
+// children to create hierarchical lists.
+type ListItem struct {
+	Text     string
+	Children []ListItem
+	Kind     ListKind // how Children are rendered (UL vs OL)
+}
+
+// Item creates a leaf ListItem with no children.
+func Item(text string) ListItem {
+	return ListItem{Text: text}
+}
+
+// Items converts multiple strings into a slice of leaf ListItems.
+func Items(texts ...string) []ListItem {
+	items := make([]ListItem, len(texts))
+	for i, t := range texts {
+		items[i] = ListItem{Text: t}
+	}
+	return items
+}
+
+// ItemWithChildren creates a ListItem whose children are rendered as an
+// unordered sub-list.
+func ItemWithChildren(text string, children ...ListItem) ListItem {
+	return ListItem{Text: text, Children: children, Kind: Unordered}
+}
+
+// ItemWithOLChildren creates a ListItem whose children are rendered as an
+// ordered sub-list.
+func ItemWithOLChildren(text string, children ...ListItem) ListItem {
+	return ListItem{Text: text, Children: children, Kind: Ordered}
+}

--- a/list_test.go
+++ b/list_test.go
@@ -1,0 +1,345 @@
+package herald
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestItem(t *testing.T) {
+	li := Item("hello")
+	if li.Text != "hello" {
+		t.Errorf("expected %q, got %q", "hello", li.Text)
+	}
+	if len(li.Children) != 0 {
+		t.Errorf("expected no children, got %d", len(li.Children))
+	}
+}
+
+func TestItems(t *testing.T) {
+	items := Items("a", "b", "c")
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+	for i, text := range []string{"a", "b", "c"} {
+		if items[i].Text != text {
+			t.Errorf("items[%d]: expected %q, got %q", i, text, items[i].Text)
+		}
+	}
+}
+
+func TestItemWithChildren(t *testing.T) {
+	li := ItemWithChildren("parent", Item("child1"), Item("child2"))
+	if li.Text != "parent" {
+		t.Errorf("expected %q, got %q", "parent", li.Text)
+	}
+	if len(li.Children) != 2 {
+		t.Errorf("expected 2 children, got %d", len(li.Children))
+	}
+	if li.Kind != Unordered {
+		t.Errorf("expected Unordered, got %d", li.Kind)
+	}
+}
+
+func TestItemWithOLChildren(t *testing.T) {
+	li := ItemWithOLChildren("parent", Item("child1"))
+	if li.Kind != Ordered {
+		t.Errorf("expected Ordered, got %d", li.Kind)
+	}
+}
+
+func TestNestUL(t *testing.T) {
+	ty := New()
+
+	t.Run("empty", func(t *testing.T) {
+		result := ty.NestUL()
+		if result != "" {
+			t.Errorf("expected empty string, got %q", result)
+		}
+	})
+
+	t.Run("flat items", func(t *testing.T) {
+		result := stripANSI(ty.NestUL(Item("a"), Item("b")))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 2 {
+			t.Fatalf("expected 2 lines, got %d: %q", len(lines), result)
+		}
+		// First level uses first bullet char
+		if !strings.Contains(lines[0], "a") {
+			t.Errorf("expected line to contain %q, got %q", "a", lines[0])
+		}
+	})
+
+	t.Run("nested items", func(t *testing.T) {
+		result := stripANSI(ty.NestUL(
+			Item("top"),
+			ItemWithChildren("parent",
+				Item("child1"),
+				Item("child2"),
+			),
+		))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 4 {
+			t.Fatalf("expected 4 lines, got %d: %q", len(lines), result)
+		}
+		// Children should be indented
+		if !strings.HasPrefix(lines[2], "  ") {
+			t.Errorf("expected child line to be indented, got %q", lines[2])
+		}
+	})
+
+	t.Run("bullet cycling", func(t *testing.T) {
+		// Build 3 levels deep
+		result := stripANSI(ty.NestUL(
+			ItemWithChildren("l0",
+				ItemWithChildren("l1",
+					Item("l2"),
+				),
+			),
+		))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 3 {
+			t.Fatalf("expected 3 lines, got %d: %q", len(lines), result)
+		}
+		// Default bullets: "•", "◦", "▪", "▹"
+		bullets := DefaultNestedBulletChars
+		if !strings.Contains(lines[0], bullets[0]) {
+			t.Errorf("depth 0: expected bullet %q in %q", bullets[0], lines[0])
+		}
+		if !strings.Contains(lines[1], bullets[1]) {
+			t.Errorf("depth 1: expected bullet %q in %q", bullets[1], lines[1])
+		}
+		if !strings.Contains(lines[2], bullets[2]) {
+			t.Errorf("depth 2: expected bullet %q in %q", bullets[2], lines[2])
+		}
+	})
+}
+
+func TestNestOL(t *testing.T) {
+	ty := New()
+
+	t.Run("empty", func(t *testing.T) {
+		result := ty.NestOL()
+		if result != "" {
+			t.Errorf("expected empty string, got %q", result)
+		}
+	})
+
+	t.Run("flat items", func(t *testing.T) {
+		result := stripANSI(ty.NestOL(Item("a"), Item("b"), Item("c")))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 3 {
+			t.Fatalf("expected 3 lines, got %d", len(lines))
+		}
+		if !strings.Contains(lines[0], "1.") {
+			t.Errorf("expected %q in %q", "1.", lines[0])
+		}
+		if !strings.Contains(lines[2], "3.") {
+			t.Errorf("expected %q in %q", "3.", lines[2])
+		}
+	})
+
+	t.Run("nested numbering resets", func(t *testing.T) {
+		result := stripANSI(ty.NestOL(
+			ItemWithOLChildren("parent",
+				Item("child1"),
+				Item("child2"),
+			),
+			Item("second"),
+		))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 4 {
+			t.Fatalf("expected 4 lines, got %d: %q", len(lines), result)
+		}
+		// Parent is 1., second is 2.
+		if !strings.Contains(lines[0], "1.") {
+			t.Errorf("expected parent to be 1., got %q", lines[0])
+		}
+		if !strings.Contains(lines[3], "2.") {
+			t.Errorf("expected second to be 2., got %q", lines[3])
+		}
+		// Children restart at 1.
+		if !strings.Contains(lines[1], "1.") {
+			t.Errorf("expected child1 to be 1., got %q", lines[1])
+		}
+		if !strings.Contains(lines[2], "2.") {
+			t.Errorf("expected child2 to be 2., got %q", lines[2])
+		}
+	})
+}
+
+func TestMixedNesting(t *testing.T) {
+	ty := New()
+
+	t.Run("OL children inside UL", func(t *testing.T) {
+		result := stripANSI(ty.NestUL(
+			ItemWithOLChildren("parent",
+				Item("first"),
+				Item("second"),
+			),
+		))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 3 {
+			t.Fatalf("expected 3 lines, got %d: %q", len(lines), result)
+		}
+		// Children should have numbered markers
+		if !strings.Contains(lines[1], "1.") {
+			t.Errorf("expected numbered child, got %q", lines[1])
+		}
+	})
+
+	t.Run("UL children inside OL", func(t *testing.T) {
+		result := stripANSI(ty.NestOL(
+			ItemWithChildren("parent",
+				Item("bullet1"),
+				Item("bullet2"),
+			),
+		))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 3 {
+			t.Fatalf("expected 3 lines, got %d: %q", len(lines), result)
+		}
+		// Parent should be numbered
+		if !strings.Contains(lines[0], "1.") {
+			t.Errorf("expected numbered parent, got %q", lines[0])
+		}
+		// Children should have bullet chars
+		if !strings.Contains(lines[1], DefaultNestedBulletChars[1]) {
+			t.Errorf("expected bullet child, got %q", lines[1])
+		}
+	})
+}
+
+func TestNestULCustomIndent(t *testing.T) {
+	ty := New(WithListIndent(4))
+
+	result := stripANSI(ty.NestUL(
+		ItemWithChildren("parent",
+			Item("child"),
+		),
+	))
+	lines := strings.Split(result, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	// Child should be indented by 4 spaces
+	if !strings.HasPrefix(lines[1], "    ") {
+		t.Errorf("expected 4-space indent, got %q", lines[1])
+	}
+}
+
+func TestNestULCustomBullets(t *testing.T) {
+	ty := New(WithNestedBulletChars([]string{"*", "o", "-", ">"}))
+
+	result := stripANSI(ty.NestUL(
+		ItemWithChildren("l0",
+			ItemWithChildren("l1",
+				Item("l2"),
+			),
+		),
+	))
+	lines := strings.Split(result, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "*") {
+		t.Errorf("depth 0: expected *, got %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "o") {
+		t.Errorf("depth 1: expected o, got %q", lines[1])
+	}
+	if !strings.Contains(lines[2], "-") {
+		t.Errorf("depth 2: expected -, got %q", lines[2])
+	}
+}
+
+func TestHierarchicalNumbers(t *testing.T) {
+	ty := New(WithHierarchicalNumbers(true))
+
+	t.Run("nested OL uses parent prefix", func(t *testing.T) {
+		result := stripANSI(ty.NestOL(
+			Item("Introduction"),
+			ItemWithOLChildren("Main Topics",
+				Item("Architecture"),
+				Item("Design"),
+			),
+			Item("Conclusion"),
+		))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 5 {
+			t.Fatalf("expected 5 lines, got %d: %q", len(lines), result)
+		}
+		// Parent items: 1., 2., 3.
+		if !strings.Contains(lines[0], "1.") {
+			t.Errorf("expected 1. in %q", lines[0])
+		}
+		if !strings.Contains(lines[1], "2.") {
+			t.Errorf("expected 2. in %q", lines[1])
+		}
+		// Children: 2.1., 2.2.
+		if !strings.Contains(lines[2], "2.1.") {
+			t.Errorf("expected 2.1. in %q", lines[2])
+		}
+		if !strings.Contains(lines[3], "2.2.") {
+			t.Errorf("expected 2.2. in %q", lines[3])
+		}
+		if !strings.Contains(lines[4], "3.") {
+			t.Errorf("expected 3. in %q", lines[4])
+		}
+	})
+
+	t.Run("three levels deep", func(t *testing.T) {
+		result := stripANSI(ty.NestOL(
+			ItemWithOLChildren("A",
+				ItemWithOLChildren("B",
+					Item("C"),
+				),
+			),
+		))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 3 {
+			t.Fatalf("expected 3 lines, got %d: %q", len(lines), result)
+		}
+		if !strings.Contains(lines[0], "1.") {
+			t.Errorf("expected 1. in %q", lines[0])
+		}
+		if !strings.Contains(lines[1], "1.1.") {
+			t.Errorf("expected 1.1. in %q", lines[1])
+		}
+		if !strings.Contains(lines[2], "1.1.1.") {
+			t.Errorf("expected 1.1.1. in %q", lines[2])
+		}
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		tyDefault := New()
+		result := stripANSI(tyDefault.NestOL(
+			ItemWithOLChildren("A",
+				Item("B"),
+			),
+		))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 2 {
+			t.Fatalf("expected 2 lines, got %d", len(lines))
+		}
+		// Child should be "1." not "1.1."
+		if strings.Contains(lines[1], "1.1.") {
+			t.Errorf("hierarchical numbering should be off by default, got %q", lines[1])
+		}
+	})
+
+	t.Run("mixed UL children skip prefix", func(t *testing.T) {
+		result := stripANSI(ty.NestOL(
+			ItemWithChildren("A",
+				Item("bullet"),
+			),
+		))
+		lines := strings.Split(result, "\n")
+		if len(lines) != 2 {
+			t.Fatalf("expected 2 lines, got %d", len(lines))
+		}
+		// UL child should use a bullet, not a number
+		if strings.Contains(lines[1], "1.1.") {
+			t.Errorf("UL children should not use hierarchical numbers, got %q", lines[1])
+		}
+	})
+}

--- a/options.go
+++ b/options.go
@@ -198,6 +198,34 @@ func WithBlockquoteBar(c string) Option {
 	return func(ty *Typography) { ty.theme.BlockquoteBar = c }
 }
 
+// --- Nested list options ---
+
+// WithListIndent sets the number of spaces per nesting level for nested lists.
+func WithListIndent(n int) Option {
+	return func(ty *Typography) {
+		if n > 0 {
+			ty.theme.ListIndent = n
+		}
+	}
+}
+
+// WithNestedBulletChars sets the bullet characters that cycle through
+// nesting levels in nested unordered lists.
+func WithNestedBulletChars(chars []string) Option {
+	return func(ty *Typography) {
+		if len(chars) > 0 {
+			ty.theme.NestedBulletChars = chars
+		}
+	}
+}
+
+// WithHierarchicalNumbers enables hierarchical numbering for nested ordered
+// lists (e.g. 1., 1.1, 1.2, 2., 2.1). When false (default), each nested
+// sub-list restarts numbering at 1.
+func WithHierarchicalNumbers(enabled bool) Option {
+	return func(ty *Typography) { ty.theme.HierarchicalNumbers = enabled }
+}
+
 // --- Callback options ---
 
 // WithCodeFormatter sets a callback that receives raw code and a language hint,

--- a/options_test.go
+++ b/options_test.go
@@ -192,6 +192,67 @@ func TestWithHeadingDecorationOptions(t *testing.T) {
 	})
 }
 
+func TestWithListIndent(t *testing.T) {
+	t.Run("positive value", func(t *testing.T) {
+		ty := New(WithListIndent(4))
+		if ty.theme.ListIndent != 4 {
+			t.Errorf("expected 4, got %d", ty.theme.ListIndent)
+		}
+	})
+
+	t.Run("zero ignored", func(t *testing.T) {
+		ty := New(WithListIndent(0))
+		if ty.theme.ListIndent != DefaultListIndent {
+			t.Errorf("expected default %d, got %d", DefaultListIndent, ty.theme.ListIndent)
+		}
+	})
+
+	t.Run("negative ignored", func(t *testing.T) {
+		ty := New(WithListIndent(-1))
+		if ty.theme.ListIndent != DefaultListIndent {
+			t.Errorf("expected default %d, got %d", DefaultListIndent, ty.theme.ListIndent)
+		}
+	})
+}
+
+func TestWithNestedBulletChars(t *testing.T) {
+	t.Run("custom chars", func(t *testing.T) {
+		chars := []string{"*", "o", "-"}
+		ty := New(WithNestedBulletChars(chars))
+		if len(ty.theme.NestedBulletChars) != 3 {
+			t.Fatalf("expected 3 chars, got %d", len(ty.theme.NestedBulletChars))
+		}
+		for i, c := range chars {
+			if ty.theme.NestedBulletChars[i] != c {
+				t.Errorf("char[%d]: expected %q, got %q", i, c, ty.theme.NestedBulletChars[i])
+			}
+		}
+	})
+
+	t.Run("empty slice ignored", func(t *testing.T) {
+		ty := New(WithNestedBulletChars([]string{}))
+		if len(ty.theme.NestedBulletChars) != len(DefaultNestedBulletChars) {
+			t.Errorf("expected default chars to be preserved")
+		}
+	})
+}
+
+func TestWithHierarchicalNumbers(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		ty := New(WithHierarchicalNumbers(true))
+		if !ty.theme.HierarchicalNumbers {
+			t.Error("expected HierarchicalNumbers to be true")
+		}
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		ty := New()
+		if ty.theme.HierarchicalNumbers {
+			t.Error("expected HierarchicalNumbers to be false by default")
+		}
+	})
+}
+
 func TestWithCodeFormatter(t *testing.T) {
 	formatter := func(code, language string) string {
 		return "[" + language + "]" + code

--- a/palette.go
+++ b/palette.go
@@ -133,9 +133,11 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		H3UnderlineChar: DefaultH3UnderlineChar,
 		HeadingBarChar:  DefaultHeadingBarChar,
 
-		BulletChar:    DefaultBulletChar,
-		HRChar:        DefaultHRChar,
-		HRWidth:       DefaultHRWidth,
-		BlockquoteBar: DefaultBlockquoteBar,
+		BulletChar:        DefaultBulletChar,
+		NestedBulletChars: DefaultNestedBulletChars,
+		ListIndent:        DefaultListIndent,
+		HRChar:            DefaultHRChar,
+		HRWidth:           DefaultHRWidth,
+		BlockquoteBar:     DefaultBlockquoteBar,
 	}
 }

--- a/theme.go
+++ b/theme.go
@@ -55,10 +55,13 @@ type Theme struct {
 	HeadingBarChar  string // left-bar prefix for H4-H6 (e.g. "▎")
 
 	// Configurable tokens
-	BulletChar    string // character used for unordered list bullets
-	HRChar        string // character repeated for horizontal rules
-	HRWidth       int    // width of horizontal rule in characters
-	BlockquoteBar string // left-bar character for blockquotes
+	BulletChar          string   // character used for unordered list bullets
+	NestedBulletChars   []string // bullet chars cycling per depth for nested lists
+	ListIndent          int      // spaces per nesting level for nested lists
+	HierarchicalNumbers bool     // use hierarchical numbering (e.g. 2.1, 2.2) for nested OL
+	HRChar              string   // character repeated for horizontal rules
+	HRWidth             int      // width of horizontal rule in characters
+	BlockquoteBar       string   // left-bar character for blockquotes
 }
 
 // Default token values used by DefaultTheme and ThemeFromPalette.
@@ -68,10 +71,15 @@ const (
 	DefaultH3UnderlineChar = "·"
 	DefaultHeadingBarChar  = "▎"
 	DefaultBulletChar      = "•"
+	DefaultListIndent      = 2
 	DefaultHRChar          = "─"
 	DefaultHRWidth         = 40
 	DefaultBlockquoteBar   = "│"
 )
+
+// DefaultNestedBulletChars is the default set of bullet characters that
+// cycle through nesting levels in nested unordered lists.
+var DefaultNestedBulletChars = []string{"•", "◦", "▪", "▹"}
 
 // hasDarkBG returns whether the terminal has a dark background.
 // It respects the HERALD_FORCE_DARK env var for tooling (e.g. screenshots).

--- a/typography.go
+++ b/typography.go
@@ -126,6 +126,54 @@ func (t *Typography) OL(items ...string) string {
 	return strings.Join(lines, "\n")
 }
 
+// NestUL renders a nested unordered list from the provided ListItems.
+func (t *Typography) NestUL(items ...ListItem) string {
+	return t.renderNestedList(items, Unordered, 0, "")
+}
+
+// NestOL renders a nested ordered list from the provided ListItems.
+func (t *Typography) NestOL(items ...ListItem) string {
+	return t.renderNestedList(items, Ordered, 0, "")
+}
+
+// renderNestedList recursively renders a list at the given depth.
+// The prefix parameter carries the parent number for hierarchical numbering
+// (e.g. "2" so children become "2.1", "2.2").
+func (t *Typography) renderNestedList(items []ListItem, kind ListKind, depth int, prefix string) string {
+	if len(items) == 0 {
+		return ""
+	}
+
+	indent := strings.Repeat(" ", depth*t.theme.ListIndent)
+	lines := make([]string, 0, len(items))
+
+	for i, item := range items {
+		var marker string
+		var childPrefix string
+		if kind == Ordered {
+			num := fmt.Sprintf("%d", i+1)
+			if t.theme.HierarchicalNumbers && prefix != "" {
+				num = prefix + "." + num
+			}
+			marker = t.theme.ListBullet.Render(num + ".")
+			childPrefix = num
+		} else {
+			chars := t.theme.NestedBulletChars
+			bullet := chars[depth%len(chars)]
+			marker = t.theme.ListBullet.Render(bullet)
+			childPrefix = ""
+		}
+		lines = append(lines, indent+marker+" "+t.theme.ListItem.Render(item.Text))
+
+		if len(item.Children) > 0 {
+			child := t.renderNestedList(item.Children, item.Kind, depth+1, childPrefix)
+			lines = append(lines, child)
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
 // Code renders inline code. If a language is provided and a CodeFormatter is
 // set on the theme, the formatter is applied before wrapping in the style.
 func (t *Typography) Code(text string, lang ...string) string {


### PR DESCRIPTION
## Summary                                                   

- Add `ListItem` type with constructors (`Item`, `Items`, `ItemWithChildren`, `ItemWithOLChildren`) for building hierarchical list structures
- Add `NestUL()` and `NestOL()` rendering methods with bullet cycling, configurable indentation, and mixed UL/OL nesting       
- Add `WithHierarchicalNumbers(true)` option for outline-style numbering (e.g. 2.1., 2.2.)                                   
- Add `WithListIndent()` and `WithNestedBulletChars()` options                                                                 
- Existing `UL()` and `OL()` methods are unchanged                                                                             
                                                                                                                                                                                 
                                                                                                                             
Closes #4