### PR TITLE
feat: add GitHub-style alert callouts

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -1,0 +1,45 @@
+package herald
+
+import "charm.land/lipgloss/v2"
+
+// AlertType identifies a GitHub-style alert category.
+type AlertType int
+
+const (
+	// AlertNote renders a blue informational alert.
+	AlertNote AlertType = iota
+	// AlertTip renders a green helpful-hint alert.
+	AlertTip
+	// AlertImportant renders a purple important-information alert.
+	AlertImportant
+	// AlertWarning renders a yellow/amber warning alert.
+	AlertWarning
+	// AlertCaution renders a red caution/danger alert.
+	AlertCaution
+)
+
+// AlertConfig holds the display properties for a single alert type.
+type AlertConfig struct {
+	Icon  string         // Unicode icon for the header line
+	Label string         // Text label (e.g. "Note")
+	Style lipgloss.Style // Foreground color applied to bar, icon, label, and content
+}
+
+// Default icon constants for each alert type. All are plain Unicode (no emoji)
+// for broad terminal compatibility.
+const (
+	DefaultAlertNoteIcon      = "ℹ"
+	DefaultAlertTipIcon       = "✦"
+	DefaultAlertImportantIcon = "‼"
+	DefaultAlertWarningIcon   = "⚠"
+	DefaultAlertCautionIcon   = "◇"
+)
+
+// Default label constants for each alert type.
+const (
+	DefaultAlertNoteLabel      = "Note"
+	DefaultAlertTipLabel       = "Tip"
+	DefaultAlertImportantLabel = "Important"
+	DefaultAlertWarningLabel   = "Warning"
+	DefaultAlertCautionLabel   = "Caution"
+)

--- a/alert_palette.go
+++ b/alert_palette.go
@@ -1,0 +1,51 @@
+package herald
+
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
+
+// AlertPalette defines the five colors used to derive alert styles. It is
+// separate from ColorPalette because the existing 9-color palette does not
+// cleanly map to 5 alert semantics.
+type AlertPalette struct {
+	Note      color.Color // blue
+	Tip       color.Color // green
+	Important color.Color // purple
+	Warning   color.Color // yellow/amber
+	Caution   color.Color // red
+}
+
+// DefaultAlertConfigs builds a full map[AlertType]AlertConfig from an
+// AlertPalette, using default icons and labels and creating a lipgloss.Style
+// with the palette color as foreground.
+func DefaultAlertConfigs(ap AlertPalette) map[AlertType]AlertConfig {
+	return map[AlertType]AlertConfig{
+		AlertNote: {
+			Icon:  DefaultAlertNoteIcon,
+			Label: DefaultAlertNoteLabel,
+			Style: lipgloss.NewStyle().Foreground(ap.Note),
+		},
+		AlertTip: {
+			Icon:  DefaultAlertTipIcon,
+			Label: DefaultAlertTipLabel,
+			Style: lipgloss.NewStyle().Foreground(ap.Tip),
+		},
+		AlertImportant: {
+			Icon:  DefaultAlertImportantIcon,
+			Label: DefaultAlertImportantLabel,
+			Style: lipgloss.NewStyle().Foreground(ap.Important),
+		},
+		AlertWarning: {
+			Icon:  DefaultAlertWarningIcon,
+			Label: DefaultAlertWarningLabel,
+			Style: lipgloss.NewStyle().Foreground(ap.Warning),
+		},
+		AlertCaution: {
+			Icon:  DefaultAlertCautionIcon,
+			Label: DefaultAlertCautionLabel,
+			Style: lipgloss.NewStyle().Foreground(ap.Caution),
+		},
+	}
+}

--- a/alert_test.go
+++ b/alert_test.go
@@ -1,0 +1,289 @@
+package herald
+
+import (
+	"image/color"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+func TestAlertRendering(t *testing.T) {
+	ty := newTestTypography()
+
+	tests := []struct {
+		name      string
+		alertType AlertType
+		text      string
+		icon      string
+		label     string
+	}{
+		{"Note", AlertNote, "Useful information.", DefaultAlertNoteIcon, DefaultAlertNoteLabel},
+		{"Tip", AlertTip, "A helpful hint.", DefaultAlertTipIcon, DefaultAlertTipLabel},
+		{"Important", AlertImportant, "Key information.", DefaultAlertImportantIcon, DefaultAlertImportantLabel},
+		{"Warning", AlertWarning, "Be careful.", DefaultAlertWarningIcon, DefaultAlertWarningLabel},
+		{"Caution", AlertCaution, "Danger ahead.", DefaultAlertCautionIcon, DefaultAlertCautionLabel},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := stripANSI(ty.Alert(tc.alertType, tc.text))
+
+			if !strings.Contains(result, tc.icon) {
+				t.Errorf("expected icon %q in %q", tc.icon, result)
+			}
+			if !strings.Contains(result, tc.label) {
+				t.Errorf("expected label %q in %q", tc.label, result)
+			}
+			if !strings.Contains(result, tc.text) {
+				t.Errorf("expected text %q in %q", tc.text, result)
+			}
+			// Every line should have the bar
+			bar := ty.theme.AlertBar
+			for line := range strings.SplitSeq(result, "\n") {
+				if !strings.HasPrefix(strings.TrimSpace(line), bar) {
+					t.Errorf("expected line to start with bar %q, got %q", bar, line)
+				}
+			}
+		})
+	}
+}
+
+func TestAlertMultiline(t *testing.T) {
+	ty := newTestTypography()
+	text := "First line.\nSecond line.\nThird line."
+	result := stripANSI(ty.Warning(text))
+
+	bar := ty.theme.AlertBar
+	lines := strings.Split(result, "\n")
+	// Header line + 3 content lines = 4 total
+	if len(lines) != 4 {
+		t.Errorf("expected 4 lines, got %d: %q", len(lines), result)
+	}
+	for i, line := range lines {
+		if !strings.Contains(line, bar) {
+			t.Errorf("line %d missing bar: %q", i, line)
+		}
+	}
+}
+
+func TestAlertEmptyText(t *testing.T) {
+	ty := newTestTypography()
+	result := stripANSI(ty.Note(""))
+
+	// Should still have header with icon and label
+	if !strings.Contains(result, DefaultAlertNoteIcon) {
+		t.Errorf("empty alert should still have icon, got %q", result)
+	}
+	if !strings.Contains(result, DefaultAlertNoteLabel) {
+		t.Errorf("empty alert should still have label, got %q", result)
+	}
+}
+
+func TestAlertConvenienceMethods(t *testing.T) {
+	ty := newTestTypography()
+
+	tests := []struct {
+		name      string
+		fn        func(string) string
+		alertType AlertType
+	}{
+		{"Note", ty.Note, AlertNote},
+		{"Tip", ty.Tip, AlertTip},
+		{"Important", ty.Important, AlertImportant},
+		{"Warning", ty.Warning, AlertWarning},
+		{"Caution", ty.Caution, AlertCaution},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			text := "Test text for " + tc.name
+			convenience := stripANSI(tc.fn(text))
+			direct := stripANSI(ty.Alert(tc.alertType, text))
+			if convenience != direct {
+				t.Errorf("%s() != Alert(%d, ...)\n  got:  %q\n  want: %q", tc.name, tc.alertType, convenience, direct)
+			}
+		})
+	}
+}
+
+func TestAlertCustomIcon(t *testing.T) {
+	ty := New(WithAlertIcon(AlertNote, ">>"))
+	result := stripANSI(ty.Note("Hello"))
+
+	if !strings.Contains(result, ">>") {
+		t.Errorf("expected custom icon '>>' in %q", result)
+	}
+	if strings.Contains(result, DefaultAlertNoteIcon) {
+		t.Errorf("should not contain default icon %q in %q", DefaultAlertNoteIcon, result)
+	}
+}
+
+func TestAlertCustomLabel(t *testing.T) {
+	ty := New(WithAlertLabel(AlertTip, "Hint"))
+	result := stripANSI(ty.Tip("Hello"))
+
+	if !strings.Contains(result, "Hint") {
+		t.Errorf("expected custom label 'Hint' in %q", result)
+	}
+	if strings.Contains(result, DefaultAlertTipLabel) {
+		t.Errorf("should not contain default label %q in %q", DefaultAlertTipLabel, result)
+	}
+}
+
+func TestAlertCustomStyle(t *testing.T) {
+	customStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+	ty := New(WithAlertStyle(AlertWarning, customStyle))
+
+	// Should not panic and should render
+	result := ty.Warning("styled")
+	if result == "" {
+		t.Error("WithAlertStyle should produce non-empty output")
+	}
+}
+
+func TestAlertBar(t *testing.T) {
+	ty := New(WithAlertBar("║"))
+	result := stripANSI(ty.Note("Hello"))
+
+	if !strings.Contains(result, "║") {
+		t.Errorf("expected custom bar '║' in %q", result)
+	}
+}
+
+func TestAlertPalette(t *testing.T) {
+	red := lipgloss.Color("#FF0000")
+	green := lipgloss.Color("#00FF00")
+	blue := lipgloss.Color("#0000FF")
+	yellow := lipgloss.Color("#FFFF00")
+	purple := lipgloss.Color("#800080")
+
+	ty := New(WithAlertPalette(AlertPalette{
+		Note:      blue,
+		Tip:       green,
+		Important: purple,
+		Warning:   yellow,
+		Caution:   red,
+	}))
+
+	// All 5 types should work and produce output
+	for _, at := range []AlertType{AlertNote, AlertTip, AlertImportant, AlertWarning, AlertCaution} {
+		result := ty.Alert(at, "test")
+		if result == "" {
+			t.Errorf("WithAlertPalette: AlertType %d produced empty output", at)
+		}
+	}
+}
+
+func TestAlertInAllThemes(t *testing.T) {
+	themes := map[string]func() Theme{
+		"Default":    DefaultTheme,
+		"Dracula":    DraculaTheme,
+		"Catppuccin": CatppuccinTheme,
+		"Base16":     Base16Theme,
+		"Charm":      CharmTheme,
+	}
+
+	alertTypes := []AlertType{AlertNote, AlertTip, AlertImportant, AlertWarning, AlertCaution}
+
+	for name, themeFn := range themes {
+		t.Run(name, func(t *testing.T) {
+			theme := themeFn()
+			if theme.Alerts == nil {
+				t.Fatalf("%s theme has nil Alerts map", name)
+			}
+			for _, at := range alertTypes {
+				cfg, ok := theme.Alerts[at]
+				if !ok {
+					t.Errorf("%s theme missing AlertType %d", name, at)
+					continue
+				}
+				if cfg.Icon == "" {
+					t.Errorf("%s theme AlertType %d has empty icon", name, at)
+				}
+				if cfg.Label == "" {
+					t.Errorf("%s theme AlertType %d has empty label", name, at)
+				}
+			}
+			if theme.AlertBar == "" {
+				t.Errorf("%s theme has empty AlertBar", name)
+			}
+		})
+	}
+}
+
+func TestAlertFallbackToBlockquote(t *testing.T) {
+	// Create a typography with an empty Alerts map to trigger fallback
+	ty := New(WithTheme(Theme{
+		Alerts:        map[AlertType]AlertConfig{},
+		AlertBar:      DefaultAlertBar,
+		BlockquoteBar: DefaultBlockquoteBar,
+		Blockquote:    lipgloss.NewStyle(),
+	}))
+
+	// An unknown/unconfigured alert type should fall back to blockquote
+	result := stripANSI(ty.Alert(AlertNote, "fallback text"))
+	if !strings.Contains(result, "fallback text") {
+		t.Errorf("fallback should contain text, got %q", result)
+	}
+	if !strings.Contains(result, DefaultBlockquoteBar) {
+		t.Errorf("fallback should use blockquote bar, got %q", result)
+	}
+}
+
+func TestAlertNilMapGuard(t *testing.T) {
+	nilTheme := Theme{
+		BlockquoteBar: DefaultBlockquoteBar,
+		Blockquote:    lipgloss.NewStyle(),
+		AlertBar:      DefaultAlertBar,
+	}
+
+	t.Run("WithAlertIcon on nil map", func(t *testing.T) {
+		ty := New(WithTheme(nilTheme), WithAlertIcon(AlertNote, "!"))
+		result := stripANSI(ty.Note("test"))
+		if !strings.Contains(result, "!") {
+			t.Errorf("expected custom icon '!' in %q", result)
+		}
+	})
+
+	t.Run("WithAlertLabel on nil map", func(t *testing.T) {
+		ty := New(WithTheme(nilTheme), WithAlertLabel(AlertNote, "Info"))
+		result := stripANSI(ty.Note("test"))
+		if !strings.Contains(result, "Info") {
+			t.Errorf("expected custom label 'Info' in %q", result)
+		}
+	})
+
+	t.Run("WithAlertStyle on nil map", func(t *testing.T) {
+		ty := New(WithTheme(nilTheme), WithAlertStyle(AlertNote, lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))))
+		result := ty.Note("test")
+		if result == "" {
+			t.Error("expected non-empty output")
+		}
+	})
+}
+
+func TestAlertPaletteFromColorPalette(t *testing.T) {
+	// Verify that ThemeFromPalette produces non-nil Alerts
+	theme := ThemeFromPalette(ColorPalette{
+		Primary:   color.Black,
+		Secondary: color.Black,
+		Tertiary:  color.Black,
+		Accent:    color.Black,
+		Highlight: color.Black,
+		Muted:     color.Black,
+		Text:      color.Black,
+		Surface:   color.Black,
+		Base:      color.Black,
+	})
+
+	if theme.Alerts == nil {
+		t.Fatal("ThemeFromPalette should produce non-nil Alerts")
+	}
+	if len(theme.Alerts) != 5 {
+		t.Errorf("expected 5 alert configs, got %d", len(theme.Alerts))
+	}
+	if theme.AlertBar == "" {
+		t.Error("ThemeFromPalette should set AlertBar")
+	}
+}

--- a/options.go
+++ b/options.go
@@ -226,6 +226,57 @@ func WithHierarchicalNumbers(enabled bool) Option {
 	return func(ty *Typography) { ty.theme.HierarchicalNumbers = enabled }
 }
 
+// --- Alert options ---
+
+// WithAlertStyle overrides the style for a specific alert type.
+func WithAlertStyle(at AlertType, s lipgloss.Style) Option {
+	return func(ty *Typography) {
+		if ty.theme.Alerts == nil {
+			ty.theme.Alerts = make(map[AlertType]AlertConfig)
+		}
+		cfg := ty.theme.Alerts[at]
+		cfg.Style = s
+		ty.theme.Alerts[at] = cfg
+	}
+}
+
+// WithAlertIcon overrides the icon for a specific alert type.
+func WithAlertIcon(at AlertType, icon string) Option {
+	return func(ty *Typography) {
+		if ty.theme.Alerts == nil {
+			ty.theme.Alerts = make(map[AlertType]AlertConfig)
+		}
+		cfg := ty.theme.Alerts[at]
+		cfg.Icon = icon
+		ty.theme.Alerts[at] = cfg
+	}
+}
+
+// WithAlertLabel overrides the label for a specific alert type.
+func WithAlertLabel(at AlertType, label string) Option {
+	return func(ty *Typography) {
+		if ty.theme.Alerts == nil {
+			ty.theme.Alerts = make(map[AlertType]AlertConfig)
+		}
+		cfg := ty.theme.Alerts[at]
+		cfg.Label = label
+		ty.theme.Alerts[at] = cfg
+	}
+}
+
+// WithAlertBar sets the left-bar character for alerts.
+func WithAlertBar(c string) Option {
+	return func(ty *Typography) { ty.theme.AlertBar = c }
+}
+
+// WithAlertPalette rebuilds all alert configs from the given AlertPalette,
+// using default icons and labels.
+func WithAlertPalette(ap AlertPalette) Option {
+	return func(ty *Typography) {
+		ty.theme.Alerts = DefaultAlertConfigs(ap)
+	}
+}
+
 // --- Callback options ---
 
 // WithCodeFormatter sets a callback that receives raw code and a language hint,

--- a/palette.go
+++ b/palette.go
@@ -139,5 +139,14 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		HRChar:            DefaultHRChar,
 		HRWidth:           DefaultHRWidth,
 		BlockquoteBar:     DefaultBlockquoteBar,
+
+		AlertBar: DefaultAlertBar,
+		Alerts: DefaultAlertConfigs(AlertPalette{
+			Note:      p.Tertiary,  // blue/cyan
+			Tip:       p.Tertiary,  // green in some palettes
+			Important: p.Secondary, // purple
+			Warning:   p.Accent,    // yellow/amber
+			Caution:   p.Highlight, // red
+		}),
 	}
 }

--- a/theme.go
+++ b/theme.go
@@ -62,6 +62,10 @@ type Theme struct {
 	HRChar              string   // character repeated for horizontal rules
 	HRWidth             int      // width of horizontal rule in characters
 	BlockquoteBar       string   // left-bar character for blockquotes
+
+	// Alert elements
+	Alerts   map[AlertType]AlertConfig // per-type icon, label, and style
+	AlertBar string                    // left-bar character for alerts
 }
 
 // Default token values used by DefaultTheme and ThemeFromPalette.
@@ -75,6 +79,7 @@ const (
 	DefaultHRChar          = "─"
 	DefaultHRWidth         = 40
 	DefaultBlockquoteBar   = "│"
+	DefaultAlertBar        = "│"
 )
 
 // DefaultNestedBulletChars is the default set of bullet characters that
@@ -94,7 +99,7 @@ func hasDarkBG() bool {
 func DefaultTheme() Theme {
 	lightDark := lipgloss.LightDark(hasDarkBG())
 
-	return ThemeFromPalette(ColorPalette{
+	theme := ThemeFromPalette(ColorPalette{
 		Primary:   lightDark(lipgloss.Color("#286983"), lipgloss.Color("#E0DEF4")), // pine / text
 		Secondary: lightDark(lipgloss.Color("#7c6f93"), lipgloss.Color("#C4A7E7")), // iris (deeper)
 		Tertiary:  lightDark(lipgloss.Color("#3e8fb0"), lipgloss.Color("#9CCFD8")), // foam (deeper)
@@ -105,4 +110,16 @@ func DefaultTheme() Theme {
 		Surface:   lightDark(lipgloss.Color("#DFDAD9"), lipgloss.Color("#393552")), // overlay (darker)
 		Base:      lightDark(lipgloss.Color("#FAF4ED"), lipgloss.Color("#191724")), // base
 	})
+
+	// Override alerts with Rose Pine-specific colors:
+	// Note=foam/blue, Tip=pine/green, Important=iris/purple, Warning=gold/amber, Caution=love/red
+	theme.Alerts = DefaultAlertConfigs(AlertPalette{
+		Note:      lightDark(lipgloss.Color("#3e8fb0"), lipgloss.Color("#9CCFD8")), // foam
+		Tip:       lightDark(lipgloss.Color("#286983"), lipgloss.Color("#31748F")), // pine
+		Important: lightDark(lipgloss.Color("#7c6f93"), lipgloss.Color("#C4A7E7")), // iris
+		Warning:   lightDark(lipgloss.Color("#D7827E"), lipgloss.Color("#F6C177")), // gold
+		Caution:   lightDark(lipgloss.Color("#B4637A"), lipgloss.Color("#EB6F92")), // love
+	})
+
+	return theme
 }

--- a/themes.go
+++ b/themes.go
@@ -10,7 +10,7 @@ import (
 func DraculaTheme() Theme {
 	lightDark := lipgloss.LightDark(hasDarkBG())
 
-	return ThemeFromPalette(ColorPalette{
+	theme := ThemeFromPalette(ColorPalette{
 		Primary:   lightDark(lipgloss.Color("#282a36"), lipgloss.Color("#f8f8f2")),
 		Secondary: lightDark(lipgloss.Color("#6d3fc0"), lipgloss.Color("#bd93f9")),
 		Tertiary:  lightDark(lipgloss.Color("#1e9651"), lipgloss.Color("#50fa7b")),
@@ -21,6 +21,16 @@ func DraculaTheme() Theme {
 		Surface:   lightDark(lipgloss.Color("#e8e6ef"), lipgloss.Color("#44475a")),
 		Base:      lightDark(lipgloss.Color("#f8f8f2"), lipgloss.Color("#282a36")),
 	})
+
+	theme.Alerts = DefaultAlertConfigs(AlertPalette{
+		Note:      lightDark(lipgloss.Color("#1e6e99"), lipgloss.Color("#8be9fd")), // cyan
+		Tip:       lightDark(lipgloss.Color("#1e9651"), lipgloss.Color("#50fa7b")), // green
+		Important: lightDark(lipgloss.Color("#6d3fc0"), lipgloss.Color("#bd93f9")), // purple
+		Warning:   lightDark(lipgloss.Color("#b07d2b"), lipgloss.Color("#f1fa8c")), // yellow
+		Caution:   lightDark(lipgloss.Color("#c44040"), lipgloss.Color("#ff5555")), // red
+	})
+
+	return theme
 }
 
 // CatppuccinTheme returns a Theme based on the Catppuccin color palette.
@@ -29,7 +39,7 @@ func DraculaTheme() Theme {
 func CatppuccinTheme() Theme {
 	lightDark := lipgloss.LightDark(hasDarkBG())
 
-	return ThemeFromPalette(ColorPalette{
+	theme := ThemeFromPalette(ColorPalette{
 		Primary:   lightDark(lipgloss.Color("#4c4f69"), lipgloss.Color("#cdd6f4")),
 		Secondary: lightDark(lipgloss.Color("#8839ef"), lipgloss.Color("#cba6f7")),
 		Tertiary:  lightDark(lipgloss.Color("#179299"), lipgloss.Color("#94e2d5")),
@@ -40,6 +50,16 @@ func CatppuccinTheme() Theme {
 		Surface:   lightDark(lipgloss.Color("#ccd0da"), lipgloss.Color("#313244")),
 		Base:      lightDark(lipgloss.Color("#eff1f5"), lipgloss.Color("#1e1e2e")),
 	})
+
+	theme.Alerts = DefaultAlertConfigs(AlertPalette{
+		Note:      lightDark(lipgloss.Color("#1e66f5"), lipgloss.Color("#89b4fa")), // blue
+		Tip:       lightDark(lipgloss.Color("#40a02b"), lipgloss.Color("#a6e3a1")), // green
+		Important: lightDark(lipgloss.Color("#8839ef"), lipgloss.Color("#cba6f7")), // mauve
+		Warning:   lightDark(lipgloss.Color("#fe640b"), lipgloss.Color("#fab387")), // peach
+		Caution:   lightDark(lipgloss.Color("#d20f39"), lipgloss.Color("#f38ba8")), // red
+	})
+
+	return theme
 }
 
 // Base16Theme returns a Theme based on ANSI base16 terminal colors.
@@ -48,7 +68,7 @@ func CatppuccinTheme() Theme {
 func Base16Theme() Theme {
 	lightDark := lipgloss.LightDark(hasDarkBG())
 
-	return ThemeFromPalette(ColorPalette{
+	theme := ThemeFromPalette(ColorPalette{
 		Primary:   lightDark(lipgloss.Color("0"), lipgloss.Color("7")),  // black / white
 		Secondary: lightDark(lipgloss.Color("4"), lipgloss.Color("6")),  // blue / cyan
 		Tertiary:  lightDark(lipgloss.Color("2"), lipgloss.Color("2")),  // green
@@ -59,6 +79,16 @@ func Base16Theme() Theme {
 		Surface:   lightDark(lipgloss.Color("15"), lipgloss.Color("8")), // bright white / bright black
 		Base:      lightDark(lipgloss.Color("7"), lipgloss.Color("0")),  // white / black
 	})
+
+	theme.Alerts = DefaultAlertConfigs(AlertPalette{
+		Note:      lightDark(lipgloss.Color("4"), lipgloss.Color("4")), // blue
+		Tip:       lightDark(lipgloss.Color("2"), lipgloss.Color("2")), // green
+		Important: lightDark(lipgloss.Color("5"), lipgloss.Color("5")), // magenta
+		Warning:   lightDark(lipgloss.Color("3"), lipgloss.Color("3")), // yellow
+		Caution:   lightDark(lipgloss.Color("1"), lipgloss.Color("1")), // red
+	})
+
+	return theme
 }
 
 // CharmTheme returns a Theme based on Charm's brand color palette.
@@ -67,7 +97,7 @@ func Base16Theme() Theme {
 func CharmTheme() Theme {
 	lightDark := lipgloss.LightDark(hasDarkBG())
 
-	return ThemeFromPalette(ColorPalette{
+	theme := ThemeFromPalette(ColorPalette{
 		Primary:   lightDark(lipgloss.Color("235"), lipgloss.Color("#FFFDF5")),
 		Secondary: lightDark(lipgloss.Color("#5A56E0"), lipgloss.Color("#7571F9")),
 		Tertiary:  lightDark(lipgloss.Color("#02BA84"), lipgloss.Color("#02BF87")),
@@ -78,4 +108,14 @@ func CharmTheme() Theme {
 		Surface:   lightDark(lipgloss.Color("254"), lipgloss.Color("238")),
 		Base:      lightDark(lipgloss.Color("252"), lipgloss.Color("236")),
 	})
+
+	theme.Alerts = DefaultAlertConfigs(AlertPalette{
+		Note:      lightDark(lipgloss.Color("#2563EB"), lipgloss.Color("#60A5FA")), // charm blue
+		Tip:       lightDark(lipgloss.Color("#02BA84"), lipgloss.Color("#02BF87")), // charm green
+		Important: lightDark(lipgloss.Color("#5A56E0"), lipgloss.Color("#7571F9")), // charm purple
+		Warning:   lightDark(lipgloss.Color("#C740B0"), lipgloss.Color("#F780E2")), // charm pink/warm
+		Caution:   lightDark(lipgloss.Color("#C7304E"), lipgloss.Color("#ED567A")), // charm red
+	})
+
+	return theme
 }

--- a/typography.go
+++ b/typography.go
@@ -273,6 +273,52 @@ func (t *Typography) Sup(text string) string {
 }
 
 // ---------------------------------------------------------------------------
+// Alerts
+// ---------------------------------------------------------------------------
+
+// Alert renders a GitHub-style alert callout. The header line (bar + icon +
+// label) is bold + colored; content lines have a colored bar but unstyled
+// text, matching GitHub's visual style. If the alert type is not configured,
+// it falls back to blockquote rendering.
+func (t *Typography) Alert(at AlertType, text string) string {
+	cfg, ok := t.theme.Alerts[at]
+	if !ok {
+		return t.Blockquote(text)
+	}
+
+	bar := t.theme.AlertBar
+	style := cfg.Style
+
+	// Header: bar + icon + label, rendered bold + colored
+	headerStyle := style.Bold(true)
+	header := headerStyle.Render(bar + " " + cfg.Icon + " " + cfg.Label)
+
+	// Content: colored bar + unstyled text (matching GitHub alerts)
+	lines := strings.Split(text, "\n")
+	content := make([]string, len(lines))
+	for i, line := range lines {
+		content[i] = style.Render(bar) + " " + line
+	}
+
+	return header + "\n" + strings.Join(content, "\n")
+}
+
+// Note renders a blue informational alert.
+func (t *Typography) Note(text string) string { return t.Alert(AlertNote, text) }
+
+// Tip renders a green helpful-hint alert.
+func (t *Typography) Tip(text string) string { return t.Alert(AlertTip, text) }
+
+// Important renders a purple important-information alert.
+func (t *Typography) Important(text string) string { return t.Alert(AlertImportant, text) }
+
+// Warning renders a yellow/amber warning alert.
+func (t *Typography) Warning(text string) string { return t.Alert(AlertWarning, text) }
+
+// Caution renders a red caution/danger alert.
+func (t *Typography) Caution(text string) string { return t.Alert(AlertCaution, text) }
+
+// ---------------------------------------------------------------------------
 // Definition list
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Add GitHub-style alert types: Note, Tip, Important, Warning, Caution. Each alert renders with a colored left bar, bold icon + label header, and unstyled content text.

## Changes

- New `AlertPalette` struct for per-theme alert color customization, separate from `ColorPalette`
- Functional options: `WithAlertStyle`, `WithAlertIcon`, `WithAlertLabel`, `WithAlertBar`, `WithAlertPalette`
- Convenience methods (`Note()`, `Tip()`, etc.) plus generic `Alert(alertType, text)`
- Alert colors defined for all built-in themes (Default, Dracula, Catppuccin, Base16, Charm)