### PR TITLE
feat: add line number support in code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,10 +435,10 @@ ty := herald.New(
 | `Tertiary`  | H3, links                                            |
 | `Accent`    | H4, mark background                                  |
 | `Highlight` | H5, `Abbr`                                           |
-| `Muted`     | H6, blockquote, HR, sub/sup, `DD`                    |
+| `Muted`     | H6, blockquote, HR, sub/sup, `DD`, line numbers      |
 | `Text`      | Body text, paragraphs, list items, inline code, `DT` |
-| `Surface`   | Background for inline code and `Kbd`                 |
-| `Base`      | Background for code blocks; mark foreground          |
+| `Surface`   | Background for `Kbd`                                 |
+| `Base`      | Background for inline code, code blocks; mark fg     |
 
 Pass the palette to `New()` via `WithPalette`, or call `ThemeFromPalette` to construct a `Theme` value directly.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ H1–H3 render with a repeated underline character beneath the text. H4–H6 ren
 | `P(text)`               | Paragraph                                                                                   |
 | `Blockquote(text)`      | Indented block with a left bar; supports multi-line input                                   |
 | `Code(text, lang)`      | Inline code with background highlight; `lang` is optional, used when a CodeFormatter is set |
-| `CodeBlock(text, lang)` | Fenced code block with padding; `lang` is optional, used when a CodeFormatter is set        |
+| `CodeBlock(text, lang)` | Fenced code block with padding; optional line numbers and syntax highlighting               |
 | `HR()`                  | Horizontal rule, configurable width and character                                           |
 | `DL(pairs)`             | Definition list from `[][2]string` pairs (term, description)                                |
 | `DT(text)`              | Definition term (standalone)                                                                |
@@ -319,28 +319,29 @@ ty := herald.New(
 
 **Style options** — each accepts a `lipgloss.Style`:
 
-| Option                        | Targets                |
-| ----------------------------- | ---------------------- |
-| `WithH1Style` – `WithH6Style` | Heading levels 1–6     |
-| `WithParagraphStyle`          | `P`                    |
-| `WithBlockquoteStyle`         | `Blockquote`           |
-| `WithCodeInlineStyle`         | `Code`                 |
-| `WithCodeBlockStyle`          | `CodeBlock`            |
-| `WithHRStyle`                 | `HR`                   |
-| `WithBoldStyle`               | `Bold`                 |
-| `WithItalicStyle`             | `Italic`               |
-| `WithUnderlineStyle`          | `Underline`            |
-| `WithStrikethroughStyle`      | `Strikethrough`        |
-| `WithSmallStyle`              | `Small`                |
-| `WithMarkStyle`               | `Mark`                 |
-| `WithLinkStyle`               | `Link`                 |
-| `WithKbdStyle`                | `Kbd`                  |
-| `WithAbbrStyle`               | `Abbr`                 |
-| `WithListBulletStyle`         | Bullet/number marker   |
-| `WithListItemStyle`           | List item text         |
-| `WithDTStyle`                 | Definition term        |
-| `WithDDStyle`                 | Definition description |
-| `WithAlertStyle(type, style)` | Alert of given type    |
+| Option                        | Targets                 |
+| ----------------------------- | ----------------------- |
+| `WithH1Style` – `WithH6Style` | Heading levels 1–6      |
+| `WithParagraphStyle`          | `P`                     |
+| `WithBlockquoteStyle`         | `Blockquote`            |
+| `WithCodeInlineStyle`         | `Code`                  |
+| `WithCodeBlockStyle`          | `CodeBlock`             |
+| `WithCodeLineNumberStyle`     | Code block line numbers |
+| `WithHRStyle`                 | `HR`                    |
+| `WithBoldStyle`               | `Bold`                  |
+| `WithItalicStyle`             | `Italic`                |
+| `WithUnderlineStyle`          | `Underline`             |
+| `WithStrikethroughStyle`      | `Strikethrough`         |
+| `WithSmallStyle`              | `Small`                 |
+| `WithMarkStyle`               | `Mark`                  |
+| `WithLinkStyle`               | `Link`                  |
+| `WithKbdStyle`                | `Kbd`                   |
+| `WithAbbrStyle`               | `Abbr`                  |
+| `WithListBulletStyle`         | Bullet/number marker    |
+| `WithListItemStyle`           | List item text          |
+| `WithDTStyle`                 | Definition term         |
+| `WithDDStyle`                 | Definition description  |
+| `WithAlertStyle(type, style)` | Alert of given type     |
 
 **Token options** — each accepts a `string` or `int`:
 
@@ -357,6 +358,8 @@ ty := herald.New(
 | `WithHRChar(c)`                | `─`                | Character repeated for `HR`                           |
 | `WithHRWidth(w)`               | `40`               | Width of `HR` in characters                           |
 | `WithBlockquoteBar(c)`         | `│`                | Left bar character for `Blockquote`                   |
+| `WithCodeLineNumbers(b)`       | `false`            | Show line numbers in `CodeBlock`                      |
+| `WithCodeLineNumberSep(c)`     | `│`                | Separator between line numbers and code               |
 | `WithAlertBar(c)`              | `│`                | Left bar character for alerts                         |
 | `WithAlertIcon(type, icon)`    | per-type           | Override icon for a specific alert type               |
 | `WithAlertLabel(type, label)`  | per-type           | Override label for a specific alert type              |
@@ -392,6 +395,34 @@ fmt.Println(ty.CodeBlock(`func main() { fmt.Println("hello") }`, "go"))
 ```
 
 See [`examples/07_syntax-highlighting/`](examples/07_syntax-highlighting/) for a chroma-based example, or [`examples/08_tree-sitter-highlighting/`](examples/08_tree-sitter-highlighting/) for a tree-sitter-based alternative.
+
+### Line numbers in code blocks
+
+Enable line numbers with `WithCodeLineNumbers(true)`. Line numbers are right-aligned, styled with `CodeLineNumber` (defaults to the `Muted` palette color), and separated from code by `CodeLineNumberSep` (default `│`). Line numbers are added after the `CodeFormatter` runs, so they work with syntax highlighting.
+
+```go
+ty := herald.New(
+    herald.WithCodeLineNumbers(true),
+)
+
+fmt.Println(ty.CodeBlock("func main() {\n\tfmt.Println(\"hello\")\n}", "go"))
+```
+
+```text
+1│ func main() {
+2│     fmt.Println("hello")
+3│ }
+```
+
+Customize the separator and style:
+
+```go
+ty := herald.New(
+    herald.WithCodeLineNumbers(true),
+    herald.WithCodeLineNumberSep(":"),
+    herald.WithCodeLineNumberStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))),
+)
+```
 
 ### Color palette
 

--- a/examples/demos/blocks/main.go
+++ b/examples/demos/blocks/main.go
@@ -19,6 +19,10 @@ func main() {
 	fmt.Println()
 	fmt.Println(ty.CodeBlock("func main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
 
+	// Code block with line numbers
+	tyLN := herald.New(herald.WithCodeLineNumbers(true))
+	fmt.Println(tyLN.CodeBlock("package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
+
 	fmt.Println(ty.HR())
 	fmt.Println()
 

--- a/options.go
+++ b/options.go
@@ -277,6 +277,23 @@ func WithAlertPalette(ap AlertPalette) Option {
 	}
 }
 
+// --- Code block line number options ---
+
+// WithCodeLineNumbers enables or disables line numbers in code blocks.
+func WithCodeLineNumbers(enabled bool) Option {
+	return func(ty *Typography) { ty.theme.ShowLineNumbers = enabled }
+}
+
+// WithCodeLineNumberStyle overrides the style for code block line numbers.
+func WithCodeLineNumberStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.CodeLineNumber = s }
+}
+
+// WithCodeLineNumberSep sets the separator between line numbers and code content.
+func WithCodeLineNumberSep(sep string) Option {
+	return func(ty *Typography) { ty.theme.CodeLineNumberSep = sep }
+}
+
 // --- Callback options ---
 
 // WithCodeFormatter sets a callback that receives raw code and a language hint,

--- a/options_test.go
+++ b/options_test.go
@@ -277,6 +277,38 @@ func TestWithCodeFormatter(t *testing.T) {
 	})
 }
 
+func TestWithCodeLineNumbers(t *testing.T) {
+	t.Run("enables line numbers", func(t *testing.T) {
+		ty := New(WithCodeLineNumbers(true))
+		if !ty.theme.ShowLineNumbers {
+			t.Error("expected ShowLineNumbers to be true")
+		}
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		ty := New()
+		if ty.theme.ShowLineNumbers {
+			t.Error("expected ShowLineNumbers to be false by default")
+		}
+	})
+}
+
+func TestWithCodeLineNumberStyle(t *testing.T) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+	ty := New(WithCodeLineNumberStyle(style))
+	result := ty.theme.CodeLineNumber.Render("1")
+	if result == "" {
+		t.Error("expected non-empty render from CodeLineNumber style")
+	}
+}
+
+func TestWithCodeLineNumberSep(t *testing.T) {
+	ty := New(WithCodeLineNumberSep(":"))
+	if ty.theme.CodeLineNumberSep != ":" {
+		t.Errorf("expected separator %q, got %q", ":", ty.theme.CodeLineNumberSep)
+	}
+}
+
 func TestMultipleOptions(t *testing.T) {
 	ty := New(
 		WithHRWidth(80),

--- a/palette.go
+++ b/palette.go
@@ -65,7 +65,7 @@ func ThemeFromPalette(p ColorPalette) Theme {
 
 		CodeInline: lipgloss.NewStyle().
 			Foreground(p.Text).
-			Background(p.Surface),
+			Background(p.Base),
 
 		CodeBlock: lipgloss.NewStyle().
 			Foreground(p.Text).

--- a/palette.go
+++ b/palette.go
@@ -140,6 +140,9 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		HRWidth:           DefaultHRWidth,
 		BlockquoteBar:     DefaultBlockquoteBar,
 
+		CodeLineNumber:    lipgloss.NewStyle().Foreground(p.Muted).Background(p.Base),
+		CodeLineNumberSep: DefaultCodeLineNumberSep,
+
 		AlertBar: DefaultAlertBar,
 		Alerts: DefaultAlertConfigs(AlertPalette{
 			Note:      p.Tertiary,  // blue/cyan

--- a/palette_test.go
+++ b/palette_test.go
@@ -150,8 +150,8 @@ func TestThemeFromPaletteColorMapping(t *testing.T) {
 			wantFg: p.Muted,
 		},
 		{
-			name: "CodeInline uses Text on Surface", style: theme.CodeInline,
-			wantFg: p.Text, wantBg: p.Surface, checkBg: true,
+			name: "CodeInline uses Text on Base", style: theme.CodeInline,
+			wantFg: p.Text, wantBg: p.Base, checkBg: true,
 		},
 		{
 			name: "CodeBlock uses Text on Base", style: theme.CodeBlock,

--- a/theme.go
+++ b/theme.go
@@ -54,6 +54,11 @@ type Theme struct {
 	H3UnderlineChar string // character repeated under H3 (e.g. "·")
 	HeadingBarChar  string // left-bar prefix for H4-H6 (e.g. "▎")
 
+	// Code block line numbers
+	CodeLineNumber    lipgloss.Style // style for line number text
+	CodeLineNumberSep string         // separator between line number and code (e.g. "│")
+	ShowLineNumbers   bool           // whether to render line numbers in CodeBlock
+
 	// Configurable tokens
 	BulletChar          string   // character used for unordered list bullets
 	NestedBulletChars   []string // bullet chars cycling per depth for nested lists
@@ -70,16 +75,17 @@ type Theme struct {
 
 // Default token values used by DefaultTheme and ThemeFromPalette.
 const (
-	DefaultH1UnderlineChar = "═"
-	DefaultH2UnderlineChar = "─"
-	DefaultH3UnderlineChar = "·"
-	DefaultHeadingBarChar  = "▎"
-	DefaultBulletChar      = "•"
-	DefaultListIndent      = 2
-	DefaultHRChar          = "─"
-	DefaultHRWidth         = 40
-	DefaultBlockquoteBar   = "│"
-	DefaultAlertBar        = "│"
+	DefaultH1UnderlineChar   = "═"
+	DefaultH2UnderlineChar   = "─"
+	DefaultH3UnderlineChar   = "·"
+	DefaultHeadingBarChar    = "▎"
+	DefaultBulletChar        = "•"
+	DefaultListIndent        = 2
+	DefaultHRChar            = "─"
+	DefaultHRWidth           = 40
+	DefaultBlockquoteBar     = "│"
+	DefaultAlertBar          = "│"
+	DefaultCodeLineNumberSep = "│"
 )
 
 // DefaultNestedBulletChars is the default set of bullet characters that

--- a/theme.go
+++ b/theme.go
@@ -111,7 +111,7 @@ func DefaultTheme() Theme {
 		Tertiary:  lightDark(lipgloss.Color("#3e8fb0"), lipgloss.Color("#9CCFD8")), // foam (deeper)
 		Accent:    lightDark(lipgloss.Color("#D7827E"), lipgloss.Color("#F6C177")), // rose / gold
 		Highlight: lightDark(lipgloss.Color("#B4637A"), lipgloss.Color("#EA9A97")), // love
-		Muted:     lightDark(lipgloss.Color("#797593"), lipgloss.Color("#6E6A86")), // subtle
+		Muted:     lightDark(lipgloss.Color("#9893A5"), lipgloss.Color("#6E6A86")), // subtle
 		Text:      lightDark(lipgloss.Color("#575279"), lipgloss.Color("#E0DEF4")), // text
 		Surface:   lightDark(lipgloss.Color("#DFDAD9"), lipgloss.Color("#393552")), // overlay (darker)
 		Base:      lightDark(lipgloss.Color("#FAF4ED"), lipgloss.Color("#191724")), // base

--- a/themes.go
+++ b/themes.go
@@ -45,7 +45,7 @@ func CatppuccinTheme() Theme {
 		Tertiary:  lightDark(lipgloss.Color("#179299"), lipgloss.Color("#94e2d5")),
 		Accent:    lightDark(lipgloss.Color("#ea76cb"), lipgloss.Color("#f5c2e7")),
 		Highlight: lightDark(lipgloss.Color("#e64553"), lipgloss.Color("#eba0ac")),
-		Muted:     lightDark(lipgloss.Color("#7c7f93"), lipgloss.Color("#6c7086")),
+		Muted:     lightDark(lipgloss.Color("#9ca0b0"), lipgloss.Color("#6c7086")),
 		Text:      lightDark(lipgloss.Color("#4c4f69"), lipgloss.Color("#cdd6f4")),
 		Surface:   lightDark(lipgloss.Color("#ccd0da"), lipgloss.Color("#313244")),
 		Base:      lightDark(lipgloss.Color("#eff1f5"), lipgloss.Color("#1e1e2e")),

--- a/themes_test.go
+++ b/themes_test.go
@@ -59,6 +59,7 @@ func assertThemeValid(t *testing.T, theme Theme) {
 			{"Sup", theme.Sup},
 			{"DT", theme.DT},
 			{"DD", theme.DD},
+			{"CodeLineNumber", theme.CodeLineNumber},
 		}
 
 		for i := range styles {
@@ -96,6 +97,12 @@ func assertThemeValid(t *testing.T, theme Theme) {
 		}
 		if theme.BlockquoteBar != DefaultBlockquoteBar {
 			t.Errorf("BlockquoteBar: expected %q, got %q", DefaultBlockquoteBar, theme.BlockquoteBar)
+		}
+		if theme.CodeLineNumberSep != DefaultCodeLineNumberSep {
+			t.Errorf("CodeLineNumberSep: expected %q, got %q", DefaultCodeLineNumberSep, theme.CodeLineNumberSep)
+		}
+		if theme.ShowLineNumbers {
+			t.Error("ShowLineNumbers should be false by default")
 		}
 	})
 

--- a/typography.go
+++ b/typography.go
@@ -186,13 +186,55 @@ func (t *Typography) Code(text string, lang ...string) string {
 
 // CodeBlock renders a fenced code block. If a language is provided and a
 // CodeFormatter is set on the theme, the formatter is applied before wrapping
-// in the style.
+// in the style. When ShowLineNumbers is true, line numbers are prepended to
+// each line after formatting.
 func (t *Typography) CodeBlock(text string, lang ...string) string {
 	content := text
 	if t.theme.CodeFormatter != nil && len(lang) > 0 && lang[0] != "" {
 		content = t.theme.CodeFormatter(text, lang[0])
 	}
+	if t.theme.ShowLineNumbers {
+		return t.codeBlockWithLineNumbers(content)
+	}
 	return t.theme.CodeBlock.Render(content)
+}
+
+// codeBlockWithLineNumbers renders a code block with a line number gutter.
+// It builds two separate columns (numbers+separator and code) and joins them
+// horizontally so that each column is independently styled, avoiding nested
+// Render calls that break background propagation.
+func (t *Typography) codeBlockWithLineNumbers(content string) string {
+	lines := strings.Split(content, "\n")
+	width := len(fmt.Sprintf("%d", len(lines)))
+
+	bg := t.theme.CodeBlock.GetBackground()
+
+	// Build the gutter column: right-aligned numbers + separator.
+	gutter := make([]string, len(lines))
+	for i := range lines {
+		gutter[i] = fmt.Sprintf("%*d", width, i+1) + t.theme.CodeLineNumberSep
+	}
+	gutterStyle := t.theme.CodeLineNumber.
+		Background(bg).
+		PaddingTop(1).
+		PaddingBottom(1).
+		PaddingLeft(2).
+		MarginBottom(t.theme.CodeBlock.GetMarginBottom())
+
+	// Build the code column with matching background and right padding.
+	codeStyle := lipgloss.NewStyle().
+		Foreground(t.theme.CodeBlock.GetForeground()).
+		Background(bg).
+		PaddingTop(1).
+		PaddingBottom(1).
+		PaddingRight(2).
+		PaddingLeft(1).
+		MarginBottom(t.theme.CodeBlock.GetMarginBottom())
+
+	return lipgloss.JoinHorizontal(lipgloss.Top,
+		gutterStyle.Render(strings.Join(gutter, "\n")),
+		codeStyle.Render(content),
+	)
 }
 
 // HR renders a horizontal rule.

--- a/typography_test.go
+++ b/typography_test.go
@@ -476,6 +476,70 @@ func TestCodeBlockWithLanguage(t *testing.T) {
 	}
 }
 
+func TestCodeBlockLineNumbers(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		ty := New()
+		result := stripANSI(ty.CodeBlock("line one\nline two"))
+		if strings.Contains(result, "1│") || strings.Contains(result, "1"+DefaultCodeLineNumberSep) {
+			t.Errorf("line numbers should be off by default, got %q", result)
+		}
+	})
+
+	t.Run("enabled shows line numbers", func(t *testing.T) {
+		ty := New(WithCodeLineNumbers(true))
+		result := stripANSI(ty.CodeBlock("aaa\nbbb\nccc"))
+		if !strings.Contains(result, "1"+DefaultCodeLineNumberSep+" aaa") {
+			t.Errorf("expected line 1 with separator, got %q", result)
+		}
+		if !strings.Contains(result, "3"+DefaultCodeLineNumberSep+" ccc") {
+			t.Errorf("expected line 3 with separator, got %q", result)
+		}
+	})
+
+	t.Run("multi-digit line numbers are right-aligned", func(t *testing.T) {
+		lines := make([]string, 12)
+		for i := range lines {
+			lines[i] = "x"
+		}
+		ty := New(WithCodeLineNumbers(true))
+		result := stripANSI(ty.CodeBlock(strings.Join(lines, "\n")))
+		// Single-digit lines should be padded: " 1│"
+		if !strings.Contains(result, " 1"+DefaultCodeLineNumberSep) {
+			t.Errorf("expected padded single-digit line number, got %q", result)
+		}
+		if !strings.Contains(result, "12"+DefaultCodeLineNumberSep) {
+			t.Errorf("expected line 12, got %q", result)
+		}
+	})
+
+	t.Run("custom separator", func(t *testing.T) {
+		ty := New(WithCodeLineNumbers(true), WithCodeLineNumberSep(":"))
+		result := stripANSI(ty.CodeBlock("hello"))
+		if !strings.Contains(result, "1: hello") {
+			t.Errorf("expected custom separator ':', got %q", result)
+		}
+	})
+
+	t.Run("with formatter", func(t *testing.T) {
+		formatter := func(code, lang string) string {
+			return "[" + code + "]"
+		}
+		ty := New(WithCodeLineNumbers(true), WithCodeFormatter(formatter))
+		result := stripANSI(ty.CodeBlock("x := 1", "go"))
+		if !strings.Contains(result, "1"+DefaultCodeLineNumberSep+" [x := 1]") {
+			t.Errorf("line numbers should wrap formatted content, got %q", result)
+		}
+	})
+
+	t.Run("single line", func(t *testing.T) {
+		ty := New(WithCodeLineNumbers(true))
+		result := stripANSI(ty.CodeBlock("only one line"))
+		if !strings.Contains(result, "1"+DefaultCodeLineNumberSep+" only one line") {
+			t.Errorf("expected single line number, got %q", result)
+		}
+	})
+}
+
 // ---------------------------------------------------------------------------
 // HR
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add opt-in line numbers for `CodeBlock` via `WithCodeLineNumbers(true)`
- New theme fields: `CodeLineNumber`, `CodeLineNumberSep`, `ShowLineNumbers`
- New options: `WithCodeLineNumbers`, `WithCodeLineNumberStyle`, `WithCodeLineNumberSep`
- Unify inline code and code block backgrounds to use `Base` consistently