### PR TITLE
docs: add demos for built in themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,12 +497,16 @@ ty := herald.New(
 
 Herald ships with named themes that match [huh](https://charm.land/huh)'s built-in color palettes. Colors auto-adapt to light/dark terminal backgrounds using `lipgloss.HasDarkBackground`.
 
-| Function            | Palette                                                           |
-| ------------------- | ----------------------------------------------------------------- |
-| `DraculaTheme()`    | [Dracula](https://draculatheme.com)                               |
-| `CatppuccinTheme()` | [Catppuccin](https://catppuccin.com) Mocha (dark) / Latte (light) |
-| `Base16Theme()`     | ANSI base16 terminal colors                                       |
-| `CharmTheme()`      | [Charm](https://charm.sh) brand colors                            |
+<table align="center">
+  <tr>
+    <td align="center" valign="middle"><code>DraculaTheme()</code><br/><img src="https://raw.githubusercontent.com/indaco/gh-assets/main/herald/demo-theme-dracula.png" alt="Dracula theme demo" width="280" /></td>
+    <td align="center" valign="middle"><code>CatppuccinTheme()</code><br/><img src="https://raw.githubusercontent.com/indaco/gh-assets/main/herald/demo-theme-catppuccin.png" alt="Catppuccin theme demo" width="280" /></td>
+  </tr>
+  <tr>
+    <td align="center" valign="middle"><code>Base16Theme()</code><br/><img src="https://raw.githubusercontent.com/indaco/gh-assets/main/herald/demo-theme-base16.png" alt="Base16 theme demo" width="280" /></td>
+    <td align="center" valign="middle"><code>CharmTheme()</code><br/><img src="https://raw.githubusercontent.com/indaco/gh-assets/main/herald/demo-theme-charm.png" alt="Charm theme demo" width="280" /></td>
+  </tr>
+</table>
 
 ```go
 ty := herald.New(herald.WithTheme(herald.DraculaTheme()))

--- a/README.md
+++ b/README.md
@@ -109,20 +109,18 @@ H1–H3 render with a repeated underline character beneath the text. H4–H6 ren
 </p>
 </details>
 
-| Method                  | Description                                                                                 |
-| ----------------------- | ------------------------------------------------------------------------------------------- |
-| `P(text)`               | Paragraph                                                                                   |
-| `Blockquote(text)`      | Indented block with a left bar; supports multi-line input                                   |
-| `Code(text, lang)`      | Inline code with background highlight; `lang` is optional, used when a CodeFormatter is set |
-| `CodeBlock(text, lang)` | Fenced code block with padding; optional line numbers and syntax highlighting               |
-| `HR()`                  | Horizontal rule, configurable width and character                                           |
-| `DL(pairs)`             | Definition list from `[][2]string` pairs (term, description)                                |
-| `DT(text)`              | Definition term (standalone)                                                                |
-| `DD(text)`              | Definition description (standalone)                                                         |
+| Method                  | Description                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `P(text)`               | Paragraph                                                                     |
+| `Blockquote(text)`      | Indented block with a left bar; supports multi-line input                     |
+| `CodeBlock(text, lang)` | Fenced code block with padding; optional line numbers and syntax highlighting |
+| `HR()`                  | Horizontal rule, configurable width and character                             |
+| `DL(pairs)`             | Definition list from `[][2]string` pairs (term, description)                  |
+| `DT(text)`              | Definition term (standalone)                                                  |
+| `DD(text)`              | Definition description (standalone)                                           |
 
 ```go
 fmt.Println(ty.Blockquote("First line.\nSecond line."))
-fmt.Println(ty.Code("os.Exit(1)"))
 fmt.Println(ty.CodeBlock("func main() {\n\tfmt.Println(\"hello\")\n}"))
 fmt.Println(ty.HR())
 
@@ -238,19 +236,20 @@ fmt.Println(ty.NestOL(
 </p>
 </details>
 
-| Method                | Renders as                                                                  |
-| --------------------- | --------------------------------------------------------------------------- |
-| `Bold(text)`          | Bold                                                                        |
-| `Italic(text)`        | Italic                                                                      |
-| `Underline(text)`     | Underlined                                                                  |
-| `Strikethrough(text)` | Strikethrough                                                               |
-| `Small(text)`         | Faint                                                                       |
-| `Mark(text)`          | Highlighted background                                                      |
-| `Link(label, url)`    | Styled link; `url` is optional — when both differ, renders as `label (url)` |
-| `Kbd(text)`           | Keyboard key indicator                                                      |
-| `Abbr(abbr, desc)`    | Abbreviation; `desc` is optional, appended in parentheses                   |
-| `Sub(text)`           | Subscript, prefixed with `_`                                                |
-| `Sup(text)`           | Superscript, prefixed with `^`                                              |
+| Method                | Renders as                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `Code(text, lang)`    | Inline code with background highlight; `lang` is optional, used when a CodeFormatter is set |
+| `Bold(text)`          | Bold                                                                                        |
+| `Italic(text)`        | Italic                                                                                      |
+| `Underline(text)`     | Underlined                                                                                  |
+| `Strikethrough(text)` | Strikethrough                                                                               |
+| `Small(text)`         | Faint                                                                                       |
+| `Mark(text)`          | Highlighted background                                                                      |
+| `Link(label, url)`    | Styled link; `url` is optional — when both differ, renders as `label (url)`                 |
+| `Kbd(text)`           | Keyboard key indicator                                                                      |
+| `Abbr(abbr, desc)`    | Abbreviation; `desc` is optional, appended in parentheses                                   |
+| `Sub(text)`           | Subscript, prefixed with `_`                                                                |
+| `Sup(text)`           | Superscript, prefixed with `^`                                                              |
 
 ```go
 fmt.Println(ty.Bold("important") + " and " + ty.Italic("nuanced"))

--- a/examples/00_default-theme/main.go
+++ b/examples/00_default-theme/main.go
@@ -23,8 +23,6 @@ func main() {
 	fmt.Println(ty.P("This is a paragraph. It wraps text with the paragraph style."))
 	fmt.Println(ty.Blockquote("A wise person once said something profound.\nAnd then said more on a second line."))
 	fmt.Println()
-	fmt.Println(ty.Code("fmt.Println()"))
-	fmt.Println()
 	fmt.Println(ty.CodeBlock("func main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
 	fmt.Println(ty.HR())
 	fmt.Println()
@@ -66,6 +64,7 @@ func main() {
 
 	// Inline styles
 	fmt.Println(ty.H3("Inline Styles"))
+	fmt.Println(ty.Code("fmt.Println()"))
 	fmt.Println(ty.Bold("Bold text"))
 	fmt.Println(ty.Italic("Italic text"))
 	fmt.Println(ty.Underline("Underlined text"))

--- a/examples/demos/blocks/main.go
+++ b/examples/demos/blocks/main.go
@@ -1,4 +1,4 @@
-// Block-level elements: paragraph, blockquote, code, code block, HR, and definition list.
+// Block-level elements: paragraph, blockquote, code block, HR, and definition list.
 // Run: go run ./examples/demos/blocks/
 package main
 
@@ -15,13 +15,12 @@ func main() {
 	fmt.Println(ty.Blockquote("A wise person once said something profound.\nAnd then said more on a second line."))
 	fmt.Println()
 
-	fmt.Println(ty.Code("fmt.Println()"))
-	fmt.Println()
 	fmt.Println(ty.CodeBlock("func main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
 
 	// Code block with line numbers
 	tyLN := herald.New(herald.WithCodeLineNumbers(true))
 	fmt.Println(tyLN.CodeBlock("package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
+	fmt.Println()
 
 	fmt.Println(ty.HR())
 	fmt.Println()

--- a/examples/demos/builtin-themes/base16/main.go
+++ b/examples/demos/builtin-themes/base16/main.go
@@ -1,0 +1,50 @@
+// Base16 theme showcase.
+// Run: go run ./examples/demos/builtin-themes/base16/
+package main
+
+import (
+	"fmt"
+
+	"github.com/indaco/herald"
+)
+
+func main() {
+	ty := herald.New(herald.WithTheme(herald.Base16Theme()))
+
+	fmt.Println(ty.H1("Base16 Theme"))
+	fmt.Println(ty.H4("Render rich text elements in your terminal"))
+
+	fmt.Println(ty.P("A Go library for HTML-analogous TUI typography, built on lipgloss v2."))
+	fmt.Println(ty.Blockquote("Good design is as little design as possible.\n— Dieter Rams"))
+	fmt.Println()
+
+	fmt.Println(ty.CodeBlock("ty := herald.New()\nfmt.Println(ty.H1(\"Hello, World!\"))"))
+
+	tyLN := herald.New(herald.WithTheme(herald.Base16Theme()), herald.WithCodeLineNumbers(true))
+	fmt.Println(tyLN.CodeBlock("package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
+
+	fmt.Println(ty.HR())
+	fmt.Println()
+
+	fmt.Println(ty.UL("Headings H1–H6", "Lists & nested lists", "Inline styles & alerts"))
+	fmt.Println()
+	fmt.Println(ty.NestOL(
+		herald.Item("Getting Started"),
+		herald.ItemWithChildren("Features",
+			herald.Item("Typography"),
+			herald.Item("Theming"),
+		),
+	))
+	fmt.Println()
+
+	fmt.Println(
+		ty.Bold("Bold") + "  " +
+			ty.Italic("Italic") + "  " +
+			ty.Mark("Highlight") + "  " +
+			ty.Kbd("Ctrl") + "+" + ty.Kbd("C") + "  " +
+			ty.Code("inline code"),
+	)
+	fmt.Println()
+
+	fmt.Println(ty.Tip("Herald supports Note, Tip, Important, Warning, and Caution alerts."))
+}

--- a/examples/demos/builtin-themes/catppuccin/main.go
+++ b/examples/demos/builtin-themes/catppuccin/main.go
@@ -1,0 +1,50 @@
+// Catppuccin theme showcase.
+// Run: go run ./examples/demos/builtin-themes/catppuccin/
+package main
+
+import (
+	"fmt"
+
+	"github.com/indaco/herald"
+)
+
+func main() {
+	ty := herald.New(herald.WithTheme(herald.CatppuccinTheme()))
+
+	fmt.Println(ty.H1("Catppuccin Theme"))
+	fmt.Println(ty.H4("Render rich text elements in your terminal"))
+
+	fmt.Println(ty.P("A Go library for HTML-analogous TUI typography, built on lipgloss v2."))
+	fmt.Println(ty.Blockquote("Good design is as little design as possible.\n— Dieter Rams"))
+	fmt.Println()
+
+	fmt.Println(ty.CodeBlock("ty := herald.New()\nfmt.Println(ty.H1(\"Hello, World!\"))"))
+
+	tyLN := herald.New(herald.WithTheme(herald.CatppuccinTheme()), herald.WithCodeLineNumbers(true))
+	fmt.Println(tyLN.CodeBlock("package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
+
+	fmt.Println(ty.HR())
+	fmt.Println()
+
+	fmt.Println(ty.UL("Headings H1–H6", "Lists & nested lists", "Inline styles & alerts"))
+	fmt.Println()
+	fmt.Println(ty.NestOL(
+		herald.Item("Getting Started"),
+		herald.ItemWithChildren("Features",
+			herald.Item("Typography"),
+			herald.Item("Theming"),
+		),
+	))
+	fmt.Println()
+
+	fmt.Println(
+		ty.Bold("Bold") + "  " +
+			ty.Italic("Italic") + "  " +
+			ty.Mark("Highlight") + "  " +
+			ty.Kbd("Ctrl") + "+" + ty.Kbd("C") + "  " +
+			ty.Code("inline code"),
+	)
+	fmt.Println()
+
+	fmt.Println(ty.Tip("Herald supports Note, Tip, Important, Warning, and Caution alerts."))
+}

--- a/examples/demos/builtin-themes/charm/main.go
+++ b/examples/demos/builtin-themes/charm/main.go
@@ -1,0 +1,50 @@
+// Charm theme showcase.
+// Run: go run ./examples/demos/builtin-themes/charm/
+package main
+
+import (
+	"fmt"
+
+	"github.com/indaco/herald"
+)
+
+func main() {
+	ty := herald.New(herald.WithTheme(herald.CharmTheme()))
+
+	fmt.Println(ty.H1("Charm Theme"))
+	fmt.Println(ty.H4("Render rich text elements in your terminal"))
+
+	fmt.Println(ty.P("A Go library for HTML-analogous TUI typography, built on lipgloss v2."))
+	fmt.Println(ty.Blockquote("Good design is as little design as possible.\n— Dieter Rams"))
+	fmt.Println()
+
+	fmt.Println(ty.CodeBlock("ty := herald.New()\nfmt.Println(ty.H1(\"Hello, World!\"))"))
+
+	tyLN := herald.New(herald.WithTheme(herald.CharmTheme()), herald.WithCodeLineNumbers(true))
+	fmt.Println(tyLN.CodeBlock("package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
+
+	fmt.Println(ty.HR())
+	fmt.Println()
+
+	fmt.Println(ty.UL("Headings H1–H6", "Lists & nested lists", "Inline styles & alerts"))
+	fmt.Println()
+	fmt.Println(ty.NestOL(
+		herald.Item("Getting Started"),
+		herald.ItemWithChildren("Features",
+			herald.Item("Typography"),
+			herald.Item("Theming"),
+		),
+	))
+	fmt.Println()
+
+	fmt.Println(
+		ty.Bold("Bold") + "  " +
+			ty.Italic("Italic") + "  " +
+			ty.Mark("Highlight") + "  " +
+			ty.Kbd("Ctrl") + "+" + ty.Kbd("C") + "  " +
+			ty.Code("inline code"),
+	)
+	fmt.Println()
+
+	fmt.Println(ty.Tip("Herald supports Note, Tip, Important, Warning, and Caution alerts."))
+}

--- a/examples/demos/builtin-themes/dracula/main.go
+++ b/examples/demos/builtin-themes/dracula/main.go
@@ -1,0 +1,50 @@
+// Dracula theme showcase.
+// Run: go run ./examples/demos/builtin-themes/dracula/
+package main
+
+import (
+	"fmt"
+
+	"github.com/indaco/herald"
+)
+
+func main() {
+	ty := herald.New(herald.WithTheme(herald.DraculaTheme()))
+
+	fmt.Println(ty.H1("Dracula Theme"))
+	fmt.Println(ty.H4("Render rich text elements in your terminal"))
+
+	fmt.Println(ty.P("A Go library for HTML-analogous TUI typography, built on lipgloss v2."))
+	fmt.Println(ty.Blockquote("Good design is as little design as possible.\n— Dieter Rams"))
+	fmt.Println()
+
+	fmt.Println(ty.CodeBlock("ty := herald.New()\nfmt.Println(ty.H1(\"Hello, World!\"))"))
+
+	tyLN := herald.New(herald.WithTheme(herald.DraculaTheme()), herald.WithCodeLineNumbers(true))
+	fmt.Println(tyLN.CodeBlock("package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
+
+	fmt.Println(ty.HR())
+	fmt.Println()
+
+	fmt.Println(ty.UL("Headings H1–H6", "Lists & nested lists", "Inline styles & alerts"))
+	fmt.Println()
+	fmt.Println(ty.NestOL(
+		herald.Item("Getting Started"),
+		herald.ItemWithChildren("Features",
+			herald.Item("Typography"),
+			herald.Item("Theming"),
+		),
+	))
+	fmt.Println()
+
+	fmt.Println(
+		ty.Bold("Bold") + "  " +
+			ty.Italic("Italic") + "  " +
+			ty.Mark("Highlight") + "  " +
+			ty.Kbd("Ctrl") + "+" + ty.Kbd("C") + "  " +
+			ty.Code("inline code"),
+	)
+	fmt.Println()
+
+	fmt.Println(ty.Tip("Herald supports Note, Tip, Important, Warning, and Caution alerts."))
+}

--- a/examples/demos/hero/main.go
+++ b/examples/demos/hero/main.go
@@ -21,8 +21,6 @@ func main() {
 	fmt.Println()
 
 	// Code
-	fmt.Println(ty.Code("go get github.com/indaco/herald"))
-	fmt.Println()
 	fmt.Println(ty.CodeBlock("ty := herald.New()\nfmt.Println(ty.H1(\"Hello, World!\"))"))
 
 	fmt.Println(ty.HR())

--- a/examples/demos/inline/main.go
+++ b/examples/demos/inline/main.go
@@ -17,6 +17,7 @@ func main() {
 	fmt.Println(ty.Strikethrough("Strikethrough text"))
 	fmt.Println(ty.Small("Small/faint text"))
 	fmt.Println(ty.Mark("Highlighted text"))
+	fmt.Println(ty.Code("inline code"))
 	fmt.Println(ty.Kbd("Ctrl") + " + " + ty.Kbd("C"))
 	fmt.Println(ty.Sub("subscript") + " and " + ty.Sup("superscript"))
 	fmt.Println()

--- a/justfile
+++ b/justfile
@@ -106,6 +106,20 @@ _capture-demo section:
         +swap -background none -layers merge +repage assets/demos/demo-{{ section }}.png
     rm -f assets/demos/demo-{{ section }}-dark.png assets/demos/demo-{{ section }}-light.png
 
+# Capture and compose a single dark+light theme demo PNG
+_capture-theme-demo name:
+    mkdir -p assets/demos
+    HERALD_FORCE_DARK=1 {{ go }} run ./examples/demos/builtin-themes/{{ name }}/ \
+        | {{ freeze }} --output assets/demos/demo-theme-{{ name }}-dark.png \
+            --theme "Catppuccin Mocha" --padding 20 --window
+    HERALD_FORCE_DARK=0 {{ go }} run ./examples/demos/builtin-themes/{{ name }}/ \
+        | {{ freeze }} --output assets/demos/demo-theme-{{ name }}-light.png \
+            --theme "Catppuccin Latte" --background "#FFFFFF" --padding 20 --window
+    magick assets/demos/demo-theme-{{ name }}-dark.png assets/demos/demo-theme-{{ name }}-light.png \
+        +append \( +clone -background black -shadow 60x20+0+10 \) \
+        +swap -background none -layers merge +repage assets/demos/demo-theme-{{ name }}.png
+    rm -f assets/demos/demo-theme-{{ name }}-dark.png assets/demos/demo-theme-{{ name }}-light.png
+
 # Generate all demo screenshots
 demo-screenshot:
     just _capture-demo hero
@@ -114,3 +128,8 @@ demo-screenshot:
     just _capture-demo lists
     just _capture-demo alerts
     just _capture-demo inline
+    just _capture-theme-demo dracula
+    just _capture-theme-demo catppuccin
+    just _capture-theme-demo base16
+    just _capture-theme-demo charm
+


### PR DESCRIPTION
## Summary

- Add demos for built-in themes in `examples/demos/themes`
- Add screenshots on the README.md to showcase the built-in themes