### PR TITLE
feat: add table rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
   <b><a href="#examples">Examples</a></b>
 </p>
 
-herald maps familiar HTML elements (H1–H6, P, Blockquote, UL, OL, Code, HR, Alerts, and inline styles) to styled terminal output, built on [lipgloss v2](https://github.com/charmbracelet/lipgloss).
+herald maps familiar HTML elements (H1–H6, P, Blockquote, UL, OL, Code, HR, Tables, Alerts, and inline styles) to styled terminal output, built on [lipgloss v2](https://github.com/charmbracelet/lipgloss).
 
 It ships with a Rose Pine-inspired default theme, built-in themes matching the Charm ecosystem (Dracula, Catppuccin, Base16, Charm), and full style customization via functional options and ColorPalette. Works with any CLI or TUI - and if you use [huh](https://github.com/charmbracelet/huh) or other Charm-based libraries, the built-in themes pair seamlessly with theirs out of the box.
 
@@ -110,15 +110,17 @@ H1–H3 render with a repeated underline character beneath the text. H4–H6 ren
 </p>
 </details>
 
-| Method                  | Description                                                                   |
-| ----------------------- | ----------------------------------------------------------------------------- |
-| `P(text)`               | Paragraph                                                                     |
-| `Blockquote(text)`      | Indented block with a left bar; supports multi-line input                     |
-| `CodeBlock(text, lang)` | Fenced code block with padding; optional line numbers and syntax highlighting |
-| `HR()`                  | Horizontal rule, configurable width and character                             |
-| `DL(pairs)`             | Definition list from `[][2]string` pairs (term, description)                  |
-| `DT(text)`              | Definition term (standalone)                                                  |
-| `DD(text)`              | Definition description (standalone)                                           |
+| Method                         | Description                                                                   |
+| ------------------------------ | ----------------------------------------------------------------------------- |
+| `P(text)`                      | Paragraph                                                                     |
+| `Blockquote(text)`             | Indented block with a left bar; supports multi-line input                     |
+| `CodeBlock(text, lang)`        | Fenced code block with padding; optional line numbers and syntax highlighting |
+| `HR()`                         | Horizontal rule, configurable width and character                             |
+| `DL(pairs)`                    | Definition list from `[][2]string` pairs (term, description)                  |
+| `DT(text)`                     | Definition term (standalone)                                                  |
+| `DD(text)`                     | Definition description (standalone)                                           |
+| `Table(rows)`                  | Table from `[][]string`; first row is the header                              |
+| `TableWithOpts(rows, opts...)` | Table with per-table options (alignment, captions, footer, etc.)              |
 
 ```go
 fmt.Println(ty.Blockquote("First line.\nSecond line."))
@@ -130,6 +132,71 @@ fmt.Println(ty.DL([][2]string{
     {"Rust", "A systems programming language"},
 }))
 ```
+
+### Tables
+
+`Table` renders a table from a `[][]string` slice. The first row is treated as the header. Two border presets are available: `BoxBorderSet()` (default, full Unicode box-drawing) and `MinimalBorderSet()` (no outer border).
+
+```go
+fmt.Println(ty.Table([][]string{
+    {"Name", "Role", "Status"},
+    {"Alice", "Admin", "Active"},
+    {"Bob", "Editor", "Idle"},
+}))
+```
+
+**Bordered (default):**
+
+```text
+┌───────┬───────┬────────┐
+│ Name  │ Role  │ Status │
+├───────┼───────┼────────┤
+│ Alice │ Admin │ Active │
+│ Bob   │ Editor│ Idle   │
+└───────┴───────┴────────┘
+```
+
+**Minimal:**
+
+```go
+ty := herald.New(herald.WithTableBorderSet(herald.MinimalBorderSet()))
+```
+
+```text
+ Name  │ Role  │ Status
+───────┼───────┼────────
+ Alice │ Admin │ Active
+ Bob   │ Editor│ Idle
+```
+
+`TableWithOpts` accepts per-table options for column alignment, row separators, striped rows, captions, and footer rows:
+
+```go
+// Column alignment, footer row, and caption
+fmt.Println(ty.TableWithOpts([][]string{
+    {"Item", "Qty", "Price"},
+    {"Widget", "10", "$9.99"},
+    {"Gadget", "5", "$24.50"},
+    {"Total", "15", "$34.49"},
+},
+    herald.WithCaption("Order Summary"),
+    herald.WithFooterRow(true),
+    herald.WithColumnAlign(1, herald.AlignRight),
+    herald.WithColumnAlign(2, herald.AlignRight),
+))
+```
+
+| Table option                  | Description                                           |
+| ----------------------------- | ----------------------------------------------------- |
+| `WithColumnAlign(col, align)` | Set alignment for a column (`AlignLeft/Center/Right`) |
+| `WithColumnAligns(aligns...)` | Set alignments for all columns positionally           |
+| `WithRowSeparators(true)`     | Horizontal lines between body rows                    |
+| `WithStripedRows(true)`       | Alternating row background for readability            |
+| `WithCaption(text)`           | Caption above the table                               |
+| `WithCaptionBottom(text)`     | Caption below the table                               |
+| `WithFooterRow(true)`         | Treat last row as a styled footer with separator      |
+| `WithMaxColumnWidth(n)`       | Truncate all columns to `n` chars with `…`            |
+| `WithColumnMaxWidth(col, n)`  | Truncate a specific column (overrides global max)     |
 
 ### Lists
 
@@ -341,28 +408,36 @@ ty := herald.New(
 | `WithListItemStyle`           | List item text          |
 | `WithDTStyle`                 | Definition term         |
 | `WithDDStyle`                 | Definition description  |
+| `WithTableHeaderStyle`        | Table header cells      |
+| `WithTableCellStyle`          | Table body cells        |
+| `WithTableStripedCellStyle`   | Alternating body rows   |
+| `WithTableFooterStyle`        | Table footer row        |
+| `WithTableCaptionStyle`       | Table caption text      |
+| `WithTableBorderStyle`        | Table border characters |
 | `WithAlertStyle(type, style)` | Alert of given type     |
 
-**Token options** — each accepts a `string` or `int`:
+**Token options** - each accepts a `string` or `int`:
 
-| Option                         | Default            | Description                                           |
-| ------------------------------ | ------------------ | ----------------------------------------------------- |
-| `WithH1UnderlineChar(c)`       | `═`                | Underline character for H1                            |
-| `WithH2UnderlineChar(c)`       | `─`                | Underline character for H2                            |
-| `WithH3UnderlineChar(c)`       | `·`                | Underline character for H3                            |
-| `WithHeadingBarChar(c)`        | `▎`                | Bar prefix character for H4–H6                        |
-| `WithBulletChar(c)`            | `•`                | Bullet character for `UL`                             |
-| `WithNestedBulletChars(chars)` | `•`, `◦`, `▪`, `▹` | Bullet characters cycling per depth for `NestUL`      |
-| `WithListIndent(n)`            | `2`                | Spaces per nesting level for `NestUL`/`NestOL`        |
-| `WithHierarchicalNumbers(b)`   | `false`            | Outline-style numbering for nested `OL` (e.g. `2.1.`) |
-| `WithHRChar(c)`                | `─`                | Character repeated for `HR`                           |
-| `WithHRWidth(w)`               | `40`               | Width of `HR` in characters                           |
-| `WithBlockquoteBar(c)`         | `│`                | Left bar character for `Blockquote`                   |
-| `WithCodeLineNumbers(b)`       | `false`            | Show line numbers in `CodeBlock`                      |
-| `WithCodeLineNumberSep(c)`     | `│`                | Separator between line numbers and code               |
-| `WithAlertBar(c)`              | `│`                | Left bar character for alerts                         |
-| `WithAlertIcon(type, icon)`    | per-type           | Override icon for a specific alert type               |
-| `WithAlertLabel(type, label)`  | per-type           | Override label for a specific alert type              |
+| Option                         | Default            | Description                                                 |
+| ------------------------------ | ------------------ | ----------------------------------------------------------- |
+| `WithH1UnderlineChar(c)`       | `═`                | Underline character for H1                                  |
+| `WithH2UnderlineChar(c)`       | `─`                | Underline character for H2                                  |
+| `WithH3UnderlineChar(c)`       | `·`                | Underline character for H3                                  |
+| `WithHeadingBarChar(c)`        | `▎`                | Bar prefix character for H4–H6                              |
+| `WithBulletChar(c)`            | `•`                | Bullet character for `UL`                                   |
+| `WithNestedBulletChars(chars)` | `•`, `◦`, `▪`, `▹` | Bullet characters cycling per depth for `NestUL`            |
+| `WithListIndent(n)`            | `2`                | Spaces per nesting level for `NestUL`/`NestOL`              |
+| `WithHierarchicalNumbers(b)`   | `false`            | Outline-style numbering for nested `OL` (e.g. `2.1.`)       |
+| `WithHRChar(c)`                | `─`                | Character repeated for `HR`                                 |
+| `WithHRWidth(w)`               | `40`               | Width of `HR` in characters                                 |
+| `WithBlockquoteBar(c)`         | `│`                | Left bar character for `Blockquote`                         |
+| `WithCodeLineNumbers(b)`       | `false`            | Show line numbers in `CodeBlock`                            |
+| `WithCodeLineNumberSep(c)`     | `│`                | Separator between line numbers and code                     |
+| `WithTableBorderSet(bs)`       | `BoxBorderSet()`   | Border character set (`BoxBorderSet` or `MinimalBorderSet`) |
+| `WithTableCellPad(n)`          | `1`                | Spaces of padding inside each table cell                    |
+| `WithAlertBar(c)`              | `│`                | Left bar character for alerts                               |
+| `WithAlertIcon(type, icon)`    | per-type           | Override icon for a specific alert type                     |
+| `WithAlertLabel(type, label)`  | per-type           | Override label for a specific alert type                    |
 
 ### Code formatting
 
@@ -428,17 +503,17 @@ ty := herald.New(
 
 `ColorPalette` lets you define 9 colors and derive a complete theme from them. All style fields map from this palette; configurable tokens use the same defaults as `DefaultTheme`.
 
-| Field       | Maps to                                              |
-| ----------- | ---------------------------------------------------- |
-| `Primary`   | H1 headings                                          |
-| `Secondary` | H2, list bullets                                     |
-| `Tertiary`  | H3, links                                            |
-| `Accent`    | H4, mark background                                  |
-| `Highlight` | H5, `Abbr`                                           |
-| `Muted`     | H6, blockquote, HR, sub/sup, `DD`, line numbers      |
-| `Text`      | Body text, paragraphs, list items, inline code, `DT` |
-| `Surface`   | Background for `Kbd`                                 |
-| `Base`      | Background for inline code, code blocks; mark fg     |
+| Field       | Maps to                                                                   |
+| ----------- | ------------------------------------------------------------------------- |
+| `Primary`   | H1 headings                                                               |
+| `Secondary` | H2, list bullets                                                          |
+| `Tertiary`  | H3, links                                                                 |
+| `Accent`    | H4, mark background                                                       |
+| `Highlight` | H5, `Abbr`                                                                |
+| `Muted`     | H6, blockquote, HR, sub/sup, `DD`, line numbers, table border, caption    |
+| `Text`      | Body text, paragraphs, list items, inline code, `DT`, table cells, footer |
+| `Surface`   | Background for `Kbd`, striped table rows                                  |
+| `Base`      | Background for inline code, code blocks; mark fg                          |
 
 Pass the palette to `New()` via `WithPalette`, or call `ThemeFromPalette` to construct a `Theme` value directly.
 

--- a/examples/09_table/main.go
+++ b/examples/09_table/main.go
@@ -1,0 +1,183 @@
+// Table rendering: bordered (default), minimal, custom padding, custom styles,
+// column alignment, row separators, striped rows, captions, footer rows,
+// and auto-truncation.
+// Run: go run ./examples/09_table/
+package main
+
+import (
+	"fmt"
+
+	"charm.land/lipgloss/v2"
+	"github.com/indaco/herald"
+)
+
+func main() {
+	// --- Bordered table (default) ---
+	ty := herald.New()
+
+	fmt.Println(ty.H3("Bordered Table (default)"))
+	fmt.Println(ty.Table([][]string{
+		{"Name", "Role", "Status"},
+		{"Alice", "Admin", "Active"},
+		{"Bob", "Editor", "Idle"},
+		{"Charlie", "Viewer", "Active"},
+	}))
+	fmt.Println()
+
+	// --- Minimal table ---
+	tyMin := herald.New(herald.WithTableBorderSet(herald.MinimalBorderSet()))
+
+	fmt.Println(ty.H3("Minimal Table"))
+	fmt.Println(tyMin.Table([][]string{
+		{"Language", "Typing", "Compiled"},
+		{"Go", "Static", "Yes"},
+		{"Python", "Dynamic", "No"},
+		{"Rust", "Static", "Yes"},
+	}))
+	fmt.Println()
+
+	// --- Custom cell padding ---
+	tyPad := herald.New(herald.WithTableCellPad(2))
+
+	fmt.Println(ty.H3("Custom Cell Padding (2)"))
+	fmt.Println(tyPad.Table([][]string{
+		{"Feature", "Herald", "Plain"},
+		{"Headings", "H1–H6", "fmt.Println"},
+		{"Lists", "UL/OL/Nested", "Manual"},
+		{"Tables", "Bordered/Minimal", "N/A"},
+	}))
+	fmt.Println()
+
+	// --- Custom styles ---
+	tyCustom := herald.New(
+		herald.WithTableHeaderStyle(lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FF6600"))),
+		herald.WithTableBorderStyle(lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#555555"))),
+		herald.WithTableCellStyle(lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#CCCCCC"))),
+	)
+
+	fmt.Println(ty.H3("Custom Styles"))
+	fmt.Println(tyCustom.Table([][]string{
+		{"Command", "Description"},
+		{"go build", "Compile packages"},
+		{"go test", "Run tests"},
+		{"go fmt", "Format source code"},
+	}))
+	fmt.Println()
+
+	// --- Column alignment ---
+	fmt.Println(ty.H3("Column Alignment"))
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"Language", "Stars", "License"},
+		{"Go", "125000", "BSD-3"},
+		{"Rust", "98000", "MIT/Apache"},
+		{"Python", "65000", "PSF"},
+	},
+		herald.WithColumnAlign(1, herald.AlignRight),
+		herald.WithColumnAlign(2, herald.AlignCenter),
+	))
+	fmt.Println()
+
+	// --- All columns aligned at once ---
+	fmt.Println(ty.H3("Bulk Column Alignment"))
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"Item", "Qty", "Price"},
+		{"Widget", "42", "$9.99"},
+		{"Gadget", "7", "$49.50"},
+		{"Doohickey", "123", "$1.25"},
+	},
+		herald.WithColumnAligns(herald.AlignLeft, herald.AlignCenter, herald.AlignRight),
+	))
+	fmt.Println()
+
+	// --- Row separators ---
+	fmt.Println(ty.H3("Row Separators"))
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"Name", "Score", "Grade"},
+		{"Alice", "95", "A"},
+		{"Bob", "82", "B"},
+		{"Charlie", "71", "C"},
+	},
+		herald.WithRowSeparators(true),
+		herald.WithColumnAlign(1, herald.AlignRight),
+	))
+	fmt.Println()
+
+	// --- Striped rows ---
+	fmt.Println(ty.H3("Striped Rows"))
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"ID", "Name", "Department"},
+		{"1", "Alice", "Engineering"},
+		{"2", "Bob", "Marketing"},
+		{"3", "Charlie", "Design"},
+		{"4", "Diana", "Engineering"},
+		{"5", "Eve", "Sales"},
+	},
+		herald.WithStripedRows(true),
+		herald.WithColumnAlign(0, herald.AlignRight),
+	))
+	fmt.Println()
+
+	// --- Caption ---
+	fmt.Println(ty.H3("Table with Caption"))
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"Language", "Year", "Creator"},
+		{"Go", "2009", "Google"},
+		{"Rust", "2010", "Mozilla"},
+		{"Zig", "2016", "A. Kelley"},
+	},
+		herald.WithCaption("Table 1: Programming Languages"),
+	))
+	fmt.Println()
+
+	// --- Caption bottom ---
+	fmt.Println(ty.H3("Table with Bottom Caption"))
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"Metric", "Value"},
+		{"Latency", "12ms"},
+		{"Throughput", "1.2k rps"},
+	},
+		herald.WithCaptionBottom("Source: internal benchmarks"),
+	))
+	fmt.Println()
+
+	// --- Footer row ---
+	fmt.Println(ty.H3("Footer Row"))
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"Item", "Qty", "Price"},
+		{"Widget", "10", "$9.99"},
+		{"Gadget", "5", "$24.50"},
+		{"Doohickey", "20", "$1.25"},
+		{"Total", "35", "$35.74"},
+	},
+		herald.WithFooterRow(true),
+		herald.WithColumnAlign(1, herald.AlignRight),
+		herald.WithColumnAlign(2, herald.AlignRight),
+	))
+	fmt.Println()
+
+	// --- Auto-truncation (global) ---
+	fmt.Println(ty.H3("Auto-Truncation (max 12)"))
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"Package", "Description"},
+		{"herald", "HTML-inspired typography for terminal UIs"},
+		{"lipgloss", "Style definitions for nice terminal layouts"},
+		{"huh", "Build interactive forms in the terminal"},
+	},
+		herald.WithMaxColumnWidth(12),
+	))
+	fmt.Println()
+
+	// --- Per-column truncation ---
+	fmt.Println(ty.H3("Per-Column Truncation"))
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"Name", "Email", "Role"},
+		{"Alice Johnson", "alice.johnson@example.com", "Administrator"},
+		{"Bob Smith", "bob.smith@example.com", "Editor"},
+	},
+		herald.WithColumnMaxWidth(1, 15),
+	))
+}

--- a/examples/demos/tables/main.go
+++ b/examples/demos/tables/main.go
@@ -1,0 +1,68 @@
+// Table elements: bordered, minimal, alignment, striped rows, caption, footer,
+// and auto-truncation.
+// Run: go run ./examples/demos/tables/
+package main
+
+import (
+	"fmt"
+
+	"github.com/indaco/herald"
+)
+
+func main() {
+	ty := herald.New()
+
+	fmt.Println(ty.Table([][]string{
+		{"Name", "Role", "Status"},
+		{"Alice", "Admin", "Active"},
+		{"Bob", "Editor", "Idle"},
+		{"Charlie", "Viewer", "Active"},
+	}))
+	fmt.Println()
+
+	tyMin := herald.New(herald.WithTableBorderSet(herald.MinimalBorderSet()))
+	fmt.Println(tyMin.Table([][]string{
+		{"Language", "Typing", "Compiled"},
+		{"Go", "Static", "Yes"},
+		{"Python", "Dynamic", "No"},
+		{"Rust", "Static", "Yes"},
+	}))
+	fmt.Println()
+
+	// Striped rows with right-aligned IDs.
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"ID", "Name", "Department"},
+		{"1", "Alice", "Engineering"},
+		{"2", "Bob", "Marketing"},
+		{"3", "Charlie", "Design"},
+		{"4", "Diana", "Sales"},
+	},
+		herald.WithStripedRows(true),
+		herald.WithColumnAlign(0, herald.AlignRight),
+	))
+	fmt.Println()
+
+	// Footer row with alignment and caption.
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"Item", "Qty", "Price"},
+		{"Widget", "10", "$9.99"},
+		{"Gadget", "5", "$24.50"},
+		{"Doohickey", "20", "$1.25"},
+		{"Total", "35", "$35.74"},
+	},
+		herald.WithCaption("Table: Order Summary"),
+		herald.WithFooterRow(true),
+		herald.WithColumnAlign(1, herald.AlignRight),
+		herald.WithColumnAlign(2, herald.AlignRight),
+	))
+	fmt.Println()
+
+	// Auto-truncation on a specific column.
+	fmt.Println(ty.TableWithOpts([][]string{
+		{"Name", "Email", "Role"},
+		{"Alice Johnson", "alice.johnson@example.com", "Admin"},
+		{"Bob Smith", "bob.smith@example.com", "Editor"},
+	},
+		herald.WithColumnMaxWidth(1, 15),
+	))
+}

--- a/herald.go
+++ b/herald.go
@@ -1,5 +1,4 @@
-// Package herald provides a reusable TUI typography library inspired by CSS
-// frameworks such as Tailwind Typography, Bootstrap, and Pico CSS.
+// Package herald provides a reusable TUI typography library.
 //
 // It offers HTML-analogous rendering functions (H1-H6, P, Blockquote, lists,
 // inline styles, etc.) that output styled strings via lipgloss v2.

--- a/justfile
+++ b/justfile
@@ -128,8 +128,8 @@ demo-screenshot:
     just _capture-demo lists
     just _capture-demo alerts
     just _capture-demo inline
+    just _capture-demo tables
     just _capture-theme-demo dracula
     just _capture-theme-demo catppuccin
     just _capture-theme-demo base16
     just _capture-theme-demo charm
-

--- a/options.go
+++ b/options.go
@@ -226,6 +226,53 @@ func WithHierarchicalNumbers(enabled bool) Option {
 	return func(ty *Typography) { ty.theme.HierarchicalNumbers = enabled }
 }
 
+// --- Table options ---
+
+// WithTableHeaderStyle overrides the table header cell style.
+func WithTableHeaderStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.TableHeader = s }
+}
+
+// WithTableCellStyle overrides the table body cell style.
+func WithTableCellStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.TableCell = s }
+}
+
+// WithTableStripedCellStyle overrides the style for alternating body rows
+// when striped rows are enabled.
+func WithTableStripedCellStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.TableStripedCell = s }
+}
+
+// WithTableFooterStyle overrides the table footer row style.
+func WithTableFooterStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.TableFooter = s }
+}
+
+// WithTableCaptionStyle overrides the table caption style.
+func WithTableCaptionStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.TableCaption = s }
+}
+
+// WithTableBorderStyle overrides the style applied to table border characters.
+func WithTableBorderStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.TableBorder = s }
+}
+
+// WithTableBorderSet sets the box-drawing character set for tables.
+func WithTableBorderSet(bs TableBorderSet) Option {
+	return func(ty *Typography) { ty.theme.TableBorderSet = bs }
+}
+
+// WithTableCellPad sets the number of spaces of padding inside each table cell.
+func WithTableCellPad(n int) Option {
+	return func(ty *Typography) {
+		if n >= 0 {
+			ty.theme.TableCellPad = n
+		}
+	}
+}
+
 // --- Alert options ---
 
 // WithAlertStyle overrides the style for a specific alert type.

--- a/palette.go
+++ b/palette.go
@@ -143,6 +143,19 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		CodeLineNumber:    lipgloss.NewStyle().Foreground(p.Muted).Background(p.Base),
 		CodeLineNumberSep: DefaultCodeLineNumberSep,
 
+		TableHeader: lipgloss.NewStyle().
+			Bold(true).
+			Foreground(p.Primary),
+		TableCell:        lipgloss.NewStyle().Foreground(p.Text),
+		TableStripedCell: lipgloss.NewStyle().Foreground(p.Text).Background(p.Surface),
+		TableFooter: lipgloss.NewStyle().
+			Bold(true).
+			Foreground(p.Text),
+		TableCaption:   lipgloss.NewStyle().Foreground(p.Muted).Italic(true),
+		TableBorder:    lipgloss.NewStyle().Foreground(p.Muted),
+		TableBorderSet: BoxBorderSet(),
+		TableCellPad:   DefaultTableCellPad,
+
 		AlertBar: DefaultAlertBar,
 		Alerts: DefaultAlertConfigs(AlertPalette{
 			Note:      p.Tertiary,  // blue/cyan

--- a/table_test.go
+++ b/table_test.go
@@ -1,0 +1,783 @@
+package herald
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+func TestTable(t *testing.T) {
+	tests := []struct {
+		name      string
+		rows      [][]string
+		wantEmpty bool
+		contains  []string
+	}{
+		{
+			name:      "nil input returns empty",
+			rows:      nil,
+			wantEmpty: true,
+		},
+		{
+			name:      "empty slice returns empty",
+			rows:      [][]string{},
+			wantEmpty: true,
+		},
+		{
+			name:      "single row with empty cells returns empty",
+			rows:      [][]string{{}},
+			wantEmpty: true,
+		},
+		{
+			name: "single column table",
+			rows: [][]string{
+				{"Name"},
+				{"Alice"},
+				{"Bob"},
+			},
+			contains: []string{"Name", "Alice", "Bob"},
+		},
+		{
+			name: "multi-column with header and body",
+			rows: [][]string{
+				{"Name", "Role", "Status"},
+				{"Alice", "Admin", "Active"},
+				{"Bob", "User", "Idle"},
+			},
+			contains: []string{
+				"Name", "Role", "Status",
+				"Alice", "Admin", "Active",
+				"Bob", "User", "Idle",
+				"┌", "┐", "└", "┘", "│", "─",
+				"├", "┤", "┬", "┴", "┼",
+			},
+		},
+		{
+			name: "ragged rows padded with empty cells",
+			rows: [][]string{
+				{"A", "B", "C"},
+				{"1"},
+				{"x", "y"},
+			},
+			contains: []string{"A", "B", "C", "1", "x", "y"},
+		},
+		{
+			name: "cells of varying widths",
+			rows: [][]string{
+				{"Short", "A much longer header"},
+				{"X", "Y"},
+			},
+			contains: []string{"Short", "A much longer header", "X", "Y"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ty := New()
+			result := ty.Table(tc.rows)
+
+			if tc.wantEmpty {
+				if result != "" {
+					t.Errorf("expected empty string, got %q", result)
+				}
+				return
+			}
+
+			plain := stripANSI(result)
+			for _, s := range tc.contains {
+				if !strings.Contains(plain, s) {
+					t.Errorf("expected output to contain %q, got:\n%s", s, plain)
+				}
+			}
+		})
+	}
+}
+
+func TestTableMinimalBorder(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()))
+	result := stripANSI(ty.Table([][]string{
+		{"Name", "Role"},
+		{"Alice", "Admin"},
+	}))
+
+	// Minimal should NOT have outer corners.
+	for _, ch := range []string{"┌", "┐", "└", "┘"} {
+		if strings.Contains(result, ch) {
+			t.Errorf("minimal border should not contain %q, got:\n%s", ch, result)
+		}
+	}
+
+	// Should still have header separator.
+	if !strings.Contains(result, "─") {
+		t.Errorf("minimal border should have header separator ─, got:\n%s", result)
+	}
+
+	// Should contain cell content.
+	if !strings.Contains(result, "Name") || !strings.Contains(result, "Alice") {
+		t.Errorf("minimal border missing cell content, got:\n%s", result)
+	}
+}
+
+func TestTableCustomCellPad(t *testing.T) {
+	tests := []struct {
+		name string
+		pad  int
+	}{
+		{"zero padding", 0},
+		{"padding of 2", 2},
+		{"padding of 3", 3},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ty := New(WithTableCellPad(tc.pad))
+			result := stripANSI(ty.Table([][]string{
+				{"A"},
+				{"B"},
+			}))
+
+			if result == "" {
+				t.Fatal("expected non-empty table output")
+			}
+
+			// Verify padding is reflected: the cell content should be surrounded
+			// by the expected number of spaces.
+			padStr := strings.Repeat(" ", tc.pad)
+			if !strings.Contains(result, padStr+"A"+padStr) {
+				t.Errorf("expected cell padding of %d spaces around 'A', got:\n%s", tc.pad, result)
+			}
+		})
+	}
+}
+
+func TestTableColumnAlignment(t *testing.T) {
+	ty := New()
+	rows := [][]string{
+		{"A", "Long Header"},
+		{"Short", "B"},
+	}
+	result := stripANSI(ty.Table(rows))
+	lines := strings.Split(result, "\n")
+
+	// All lines in a bordered table should have the same visible width.
+	if len(lines) < 2 {
+		t.Fatalf("expected multiple lines, got %d", len(lines))
+	}
+
+	width := len([]rune(lines[0]))
+	for i, line := range lines {
+		if len([]rune(line)) != width {
+			t.Errorf("line %d width %d != expected %d:\n%s", i, len([]rune(line)), width, result)
+		}
+	}
+}
+
+func TestTableOptions(t *testing.T) {
+	t.Run("WithTableHeaderStyle", func(t *testing.T) {
+		ty := New(WithTableHeaderStyle(lipgloss.NewStyle().Bold(true)))
+		result := ty.Table([][]string{{"H"}, {"D"}})
+		if result == "" {
+			t.Error("expected non-empty output")
+		}
+	})
+
+	t.Run("WithTableCellStyle", func(t *testing.T) {
+		ty := New(WithTableCellStyle(lipgloss.NewStyle().Italic(true)))
+		result := ty.Table([][]string{{"H"}, {"D"}})
+		if result == "" {
+			t.Error("expected non-empty output")
+		}
+	})
+
+	t.Run("WithTableBorderStyle", func(t *testing.T) {
+		ty := New(WithTableBorderStyle(lipgloss.NewStyle().Faint(true)))
+		result := ty.Table([][]string{{"H"}, {"D"}})
+		if result == "" {
+			t.Error("expected non-empty output")
+		}
+	})
+
+	t.Run("WithTableBorderSet", func(t *testing.T) {
+		ty := New(WithTableBorderSet(MinimalBorderSet()))
+		result := stripANSI(ty.Table([][]string{{"H"}, {"D"}}))
+		if strings.Contains(result, "┌") {
+			t.Error("expected minimal border without corners")
+		}
+	})
+
+	t.Run("WithTableCellPad negative ignored", func(t *testing.T) {
+		ty := New(WithTableCellPad(-1))
+		if ty.theme.TableCellPad != DefaultTableCellPad {
+			t.Errorf("negative pad should be ignored, got %d", ty.theme.TableCellPad)
+		}
+	})
+}
+
+func TestTableHeaderOnly(t *testing.T) {
+	ty := New()
+	result := stripANSI(ty.Table([][]string{
+		{"Name", "Role"},
+	}))
+
+	// Should still render the header with borders.
+	if !strings.Contains(result, "Name") {
+		t.Errorf("header-only table should contain header text, got:\n%s", result)
+	}
+	if !strings.Contains(result, "┌") {
+		t.Errorf("header-only table should have top border, got:\n%s", result)
+	}
+}
+
+func TestTableSpecialCharacters(t *testing.T) {
+	ty := New()
+	// Should not panic on special characters.
+	result := ty.Table([][]string{
+		{"<script>", "a & b"},
+		{"\t\n", ""},
+	})
+	if result == "" {
+		t.Error("expected non-empty output for special characters")
+	}
+}
+
+func TestTableConcurrency(t *testing.T) {
+	ty := New()
+	done := make(chan struct{})
+
+	for range 10 {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			ty.Table([][]string{
+				{"Name", "Role"},
+				{"Alice", "Admin"},
+			})
+		}()
+	}
+
+	for range 10 {
+		<-done
+	}
+}
+
+func TestTableWithOptsEmpty(t *testing.T) {
+	ty := New()
+	if got := ty.TableWithOpts(nil); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+	if got := ty.TableWithOpts([][]string{}); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestTableWithOptsMatchesTable(t *testing.T) {
+	ty := New()
+	rows := [][]string{
+		{"Name", "Role"},
+		{"Alice", "Admin"},
+	}
+	want := ty.Table(rows)
+	got := ty.TableWithOpts(rows)
+	if got != want {
+		t.Errorf("TableWithOpts with no opts should match Table\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestTableWithOptsAlignRight(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"X", "Y"},
+		{"AB", "C"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows, WithColumnAlign(0, AlignRight)))
+	lines := strings.Split(result, "\n")
+	if !strings.Contains(lines[0], " X") {
+		t.Errorf("expected right-aligned 'X' with leading space, got line: %q", lines[0])
+	}
+}
+
+func TestTableWithOptsAlignCenter(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"ABCDE"},
+		{"X"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows, WithColumnAlign(0, AlignCenter)))
+	lines := strings.Split(result, "\n")
+	bodyLine := lines[2]
+	if !strings.Contains(bodyLine, "  X  ") {
+		t.Errorf("expected centered 'X' as '  X  ', got line: %q", bodyLine)
+	}
+}
+
+func TestTableWithOptsAlignLeftDefault(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"ABC"},
+		{"X"},
+	}
+	withOpt := stripANSI(ty.TableWithOpts(rows, WithColumnAlign(0, AlignLeft)))
+	without := stripANSI(ty.Table(rows))
+	if withOpt != without {
+		t.Errorf("explicit AlignLeft should match default\ngot:\n%s\nwant:\n%s", withOpt, without)
+	}
+}
+
+func TestTableWithOptsMixedAlignments(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"Left", "Center", "Right"},
+		{"A", "B", "C"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows,
+		WithColumnAlign(0, AlignLeft),
+		WithColumnAlign(1, AlignCenter),
+		WithColumnAlign(2, AlignRight),
+	))
+	lines := strings.Split(result, "\n")
+	bodyLine := lines[2]
+
+	if !strings.Contains(bodyLine, "A   ") {
+		t.Errorf("expected left-aligned 'A' with trailing spaces, got: %q", bodyLine)
+	}
+	if !strings.Contains(bodyLine, "  B   ") {
+		t.Errorf("expected centered 'B', got: %q", bodyLine)
+	}
+	if !strings.Contains(bodyLine, "    C") {
+		t.Errorf("expected right-aligned 'C' with leading spaces, got: %q", bodyLine)
+	}
+}
+
+func TestTableWithOptsColumnAligns(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"AAA", "BBB"},
+		{"X", "Y"},
+	}
+	resultA := stripANSI(ty.TableWithOpts(rows,
+		WithColumnAlign(0, AlignRight),
+		WithColumnAlign(1, AlignCenter),
+	))
+	resultB := stripANSI(ty.TableWithOpts(rows,
+		WithColumnAligns(AlignRight, AlignCenter),
+	))
+	if resultA != resultB {
+		t.Errorf("WithColumnAligns should match individual WithColumnAlign calls\ngot:\n%s\nwant:\n%s", resultB, resultA)
+	}
+}
+
+func TestTableWithOptsOutOfRange(t *testing.T) {
+	ty := New()
+	rows := [][]string{
+		{"A", "B"},
+		{"C", "D"},
+	}
+	result := ty.TableWithOpts(rows, WithColumnAlign(99, AlignRight))
+	if result == "" {
+		t.Error("expected non-empty output")
+	}
+}
+
+func TestTableWithOptsBorderedAlignment(t *testing.T) {
+	ty := New(WithTableCellPad(0))
+	rows := [][]string{
+		{"Name", "Score"},
+		{"A", "100"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows, WithColumnAlign(1, AlignRight)))
+	if !strings.Contains(result, "  100") {
+		t.Errorf("expected right-aligned '100' with leading spaces, got:\n%s", result)
+	}
+}
+
+func TestTableWithOptsUniformWidth(t *testing.T) {
+	ty := New()
+	rows := [][]string{
+		{"A", "Long Header"},
+		{"Short", "B"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows,
+		WithColumnAlign(0, AlignRight),
+		WithColumnAlign(1, AlignCenter),
+	))
+	lines := strings.Split(result, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected multiple lines, got %d", len(lines))
+	}
+	width := len([]rune(lines[0]))
+	for i, line := range lines {
+		if len([]rune(line)) != width {
+			t.Errorf("line %d width %d != expected %d:\n%s", i, len([]rune(line)), width, result)
+		}
+	}
+}
+
+func TestTableWithOptsRowSeparatorsBordered(t *testing.T) {
+	ty := New(WithTableCellPad(0))
+	rows := [][]string{
+		{"A", "B"},
+		{"C", "D"},
+		{"E", "F"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows, WithRowSeparators(true)))
+	lines := strings.Split(result, "\n")
+	// Bordered: top, header, header-sep, row1, row-sep, row2, bottom = 7 lines.
+	if len(lines) != 7 {
+		t.Fatalf("expected 7 lines, got %d:\n%s", len(lines), result)
+	}
+	// Row separator (line index 4) should contain junction characters.
+	if !strings.Contains(lines[4], "─") {
+		t.Errorf("expected row separator with ─, got: %q", lines[4])
+	}
+}
+
+func TestTableWithOptsRowSeparatorsMinimal(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"A", "B"},
+		{"C", "D"},
+		{"E", "F"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows, WithRowSeparators(true)))
+	lines := strings.Split(result, "\n")
+	// Minimal: header, header-sep, row1, row-sep, row2 = 5 lines.
+	if len(lines) != 5 {
+		t.Fatalf("expected 5 lines, got %d:\n%s", len(lines), result)
+	}
+}
+
+func TestTableWithOptsRowSeparatorsDisabled(t *testing.T) {
+	ty := New(WithTableCellPad(0))
+	rows := [][]string{
+		{"A", "B"},
+		{"C", "D"},
+		{"E", "F"},
+	}
+	withSep := ty.TableWithOpts(rows, WithRowSeparators(false))
+	without := ty.Table(rows)
+	if withSep != without {
+		t.Errorf("WithRowSeparators(false) should match Table output")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Striped rows
+// ---------------------------------------------------------------------------
+
+func TestTableStripedRows(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"H"},
+		{"A"},
+		{"B"},
+		{"C"},
+		{"D"},
+	}
+	result := ty.TableWithOpts(rows, WithStripedRows(true))
+	// Should produce output without panic.
+	if result == "" {
+		t.Error("expected non-empty output")
+	}
+	plain := ty.Table(rows)
+	if result == plain {
+		t.Error("striped output should differ from plain output")
+	}
+}
+
+func TestTableStripedRowsDisabled(t *testing.T) {
+	ty := New(WithTableCellPad(0))
+	rows := [][]string{
+		{"H"},
+		{"A"},
+		{"B"},
+	}
+	withOpt := ty.TableWithOpts(rows, WithStripedRows(false))
+	without := ty.Table(rows)
+	if withOpt != without {
+		t.Error("WithStripedRows(false) should match Table output")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Caption
+// ---------------------------------------------------------------------------
+
+func TestTableCaptionTop(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"A"},
+		{"B"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows, WithCaption("My Table")))
+	lines := strings.Split(result, "\n")
+	if lines[0] != "My Table" {
+		t.Errorf("expected first line to be caption, got: %q", lines[0])
+	}
+}
+
+func TestTableCaptionBottom(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"A"},
+		{"B"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows, WithCaptionBottom("Source: test")))
+	lines := strings.Split(result, "\n")
+	last := lines[len(lines)-1]
+	if last != "Source: test" {
+		t.Errorf("expected last line to be caption, got: %q", last)
+	}
+}
+
+func TestTableCaptionEmpty(t *testing.T) {
+	ty := New(WithTableCellPad(0))
+	rows := [][]string{
+		{"A"},
+		{"B"},
+	}
+	withCaption := ty.TableWithOpts(rows, WithCaption(""))
+	without := ty.Table(rows)
+	if withCaption != without {
+		t.Error("empty caption should not change output")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Footer row
+// ---------------------------------------------------------------------------
+
+func TestTableFooterRow(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"Item", "Price"},
+		{"Widget", "$10"},
+		{"Gadget", "$20"},
+		{"Total", "$30"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows, WithFooterRow(true)))
+	// Should contain a footer separator and the footer row.
+	if !strings.Contains(result, "Total") {
+		t.Error("expected footer row with 'Total'")
+	}
+	// Footer separator should appear (a second ─ line after body).
+	lines := strings.Split(result, "\n")
+	sepCount := 0
+	for _, line := range lines {
+		if strings.Contains(line, "─") {
+			sepCount++
+		}
+	}
+	// Header sep + footer sep = 2.
+	if sepCount != 2 {
+		t.Errorf("expected 2 separator lines, got %d", sepCount)
+	}
+}
+
+func TestTableFooterRowBordered(t *testing.T) {
+	ty := New(WithTableCellPad(0))
+	rows := [][]string{
+		{"H1", "H2"},
+		{"A", "B"},
+		{"Footer1", "Footer2"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows, WithFooterRow(true)))
+	if !strings.Contains(result, "Footer1") {
+		t.Error("expected footer row content")
+	}
+	// All lines should be same width.
+	lines := strings.Split(result, "\n")
+	width := len([]rune(lines[0]))
+	for i, line := range lines {
+		if len([]rune(line)) != width {
+			t.Errorf("line %d width %d != %d:\n%s", i, len([]rune(line)), width, result)
+		}
+	}
+}
+
+func TestTableFooterRowTooFewRows(t *testing.T) {
+	ty := New(WithTableCellPad(0))
+	// Only header + 1 body row: footer should not activate.
+	rows := [][]string{
+		{"H"},
+		{"A"},
+	}
+	withFooter := ty.TableWithOpts(rows, WithFooterRow(true))
+	without := ty.Table(rows)
+	if withFooter != without {
+		t.Error("footer should not activate with <= 2 rows")
+	}
+}
+
+func TestTableFooterRowDisabled(t *testing.T) {
+	ty := New(WithTableCellPad(0))
+	rows := [][]string{
+		{"H"},
+		{"A"},
+		{"B"},
+	}
+	withFooter := ty.TableWithOpts(rows, WithFooterRow(false))
+	without := ty.Table(rows)
+	if withFooter != without {
+		t.Error("WithFooterRow(false) should match Table output")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Theme-level options for new styles
+// ---------------------------------------------------------------------------
+
+func TestTableStyleOptions(t *testing.T) {
+	t.Run("WithTableStripedCellStyle", func(t *testing.T) {
+		ty := New(WithTableStripedCellStyle(lipgloss.NewStyle().Faint(true)))
+		result := ty.TableWithOpts([][]string{{"H"}, {"A"}, {"B"}}, WithStripedRows(true))
+		if result == "" {
+			t.Error("expected non-empty output")
+		}
+	})
+
+	t.Run("WithTableFooterStyle", func(t *testing.T) {
+		ty := New(WithTableFooterStyle(lipgloss.NewStyle().Bold(true)))
+		result := ty.TableWithOpts([][]string{{"H"}, {"A"}, {"F"}}, WithFooterRow(true))
+		if result == "" {
+			t.Error("expected non-empty output")
+		}
+	})
+
+	t.Run("WithTableCaptionStyle", func(t *testing.T) {
+		ty := New(WithTableCaptionStyle(lipgloss.NewStyle().Italic(true)))
+		result := ty.TableWithOpts([][]string{{"H"}, {"A"}}, WithCaption("cap"))
+		if result == "" {
+			t.Error("expected non-empty output")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Auto-truncation
+// ---------------------------------------------------------------------------
+
+func TestTruncateCell(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxWidth int
+		want     string
+	}{
+		{"no truncation needed", "Hello", 10, "Hello"},
+		{"exact fit", "Hello", 5, "Hello"},
+		{"truncate with ellipsis", "Hello World", 8, "Hello W…"},
+		{"truncate to 1", "Hello", 1, "…"},
+		{"zero max disables", "Hello", 0, "Hello"},
+		{"negative max disables", "Hello", -1, "Hello"},
+		{"empty string", "", 5, ""},
+		{"single char truncate", "AB", 1, "…"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateCell(tc.input, tc.maxWidth)
+			if got != tc.want {
+				t.Errorf("truncateCell(%q, %d) = %q, want %q", tc.input, tc.maxWidth, got, tc.want)
+			}
+			if tc.maxWidth > 0 && lipgloss.Width(got) > tc.maxWidth {
+				t.Errorf("result width %d exceeds max %d", lipgloss.Width(got), tc.maxWidth)
+			}
+		})
+	}
+}
+
+func TestTableWithOptsMaxColumnWidth(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"Name", "Description"},
+		{"Go", "A statically typed compiled language"},
+	}
+	result := stripANSI(ty.TableWithOpts(rows, WithMaxColumnWidth(10)))
+	// "A statically typed compiled language" should be truncated.
+	if strings.Contains(result, "compiled language") {
+		t.Error("expected long cell to be truncated")
+	}
+	if !strings.Contains(result, "…") {
+		t.Error("expected ellipsis in truncated cell")
+	}
+}
+
+func TestTableWithOptsColumnMaxWidth(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"Name", "Description"},
+		{"Go", "A compiled language"},
+	}
+	// Only truncate column 1.
+	result := stripANSI(ty.TableWithOpts(rows, WithColumnMaxWidth(1, 8)))
+	lines := strings.Split(result, "\n")
+	// Header "Description" should be truncated.
+	if !strings.Contains(lines[0], "…") {
+		t.Errorf("expected header cell truncated, got: %q", lines[0])
+	}
+	// Column 0 ("Name", "Go") should not be truncated.
+	if strings.Contains(lines[0], "Na…") {
+		t.Error("column 0 should not be truncated")
+	}
+}
+
+func TestTableWithOptsColumnMaxWidthOverridesGlobal(t *testing.T) {
+	ty := New(WithTableBorderSet(MinimalBorderSet()), WithTableCellPad(0))
+	rows := [][]string{
+		{"LongName", "VeryLongContent"},
+	}
+	// Global max=5, but column 1 has max=15 (no truncation for col 1).
+	result := stripANSI(ty.TableWithOpts(rows,
+		WithMaxColumnWidth(5),
+		WithColumnMaxWidth(1, 15),
+	))
+	if !strings.Contains(result, "VeryLongContent") {
+		t.Error("column 1 should not be truncated (per-column override)")
+	}
+	if !strings.Contains(result, "Long…") {
+		t.Errorf("column 0 should be truncated by global max, got: %s", result)
+	}
+}
+
+func TestTableWithOptsNoTruncation(t *testing.T) {
+	ty := New(WithTableCellPad(0))
+	rows := [][]string{
+		{"A"},
+		{"B"},
+	}
+	// MaxColumnWidth(0) should not change output.
+	withOpt := ty.TableWithOpts(rows, WithMaxColumnWidth(0))
+	without := ty.Table(rows)
+	if withOpt != without {
+		t.Error("WithMaxColumnWidth(0) should not change output")
+	}
+}
+
+func TestAlignCell(t *testing.T) {
+	tests := []struct {
+		name      string
+		text      string
+		cellWidth int
+		total     int
+		align     Alignment
+		want      string
+	}{
+		{"left pad", "X", 1, 5, AlignLeft, "X    "},
+		{"right pad", "X", 1, 5, AlignRight, "    X"},
+		{"center even", "XX", 2, 6, AlignCenter, "  XX  "},
+		{"center odd", "X", 1, 6, AlignCenter, "  X   "},
+		{"no gap", "ABCDE", 5, 5, AlignLeft, "ABCDE"},
+		{"no gap right", "ABCDE", 5, 5, AlignRight, "ABCDE"},
+		{"no gap center", "ABCDE", 5, 5, AlignCenter, "ABCDE"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := alignCell(tc.text, tc.cellWidth, tc.total, tc.align)
+			if got != tc.want {
+				t.Errorf("alignCell(%q, %d, %d, %d) = %q, want %q",
+					tc.text, tc.cellWidth, tc.total, tc.align, got, tc.want)
+			}
+		})
+	}
+}

--- a/theme.go
+++ b/theme.go
@@ -68,9 +68,89 @@ type Theme struct {
 	HRWidth             int      // width of horizontal rule in characters
 	BlockquoteBar       string   // left-bar character for blockquotes
 
+	// Table elements
+	TableHeader      lipgloss.Style // style for header cell text (e.g. bold + primary color)
+	TableCell        lipgloss.Style // style for body cell text
+	TableStripedCell lipgloss.Style // style for alternating (odd) body rows when striping is enabled
+	TableFooter      lipgloss.Style // style for footer row cells
+	TableCaption     lipgloss.Style // style for table caption text
+	TableBorder      lipgloss.Style // style (color) applied to border characters
+	TableBorderSet   TableBorderSet // box-drawing character set
+	TableCellPad     int            // spaces of padding inside each cell (default 1)
+
 	// Alert elements
 	Alerts   map[AlertType]AlertConfig // per-type icon, label, and style
 	AlertBar string                    // left-bar character for alerts
+}
+
+// TableBorderSet holds all box-drawing characters needed to render a table.
+type TableBorderSet struct {
+	Top            string // horizontal line for top border
+	Bottom         string // horizontal line for bottom border
+	Left           string // vertical line for left border
+	Right          string // vertical line for right border
+	Header         string // horizontal line separating header from body
+	Row            string // horizontal line between rows (optional, empty = no row separators)
+	TopLeft        string // top-left corner
+	TopRight       string // top-right corner
+	BottomLeft     string // bottom-left corner
+	BottomRight    string // bottom-right corner
+	TopJunction    string // top edge junction (┬)
+	BottomJunction string // bottom edge junction (┴)
+	LeftJunction   string // left edge junction (├)
+	RightJunction  string // right edge junction (┤)
+	Cross          string // interior junction (┼)
+	HeaderLeft     string // header-row left junction
+	HeaderRight    string // header-row right junction
+	HeaderCross    string // header-row interior junction
+	FooterLeft     string // footer-row left junction
+	FooterRight    string // footer-row right junction
+	FooterCross    string // footer-row interior junction
+}
+
+// BoxBorderSet returns a TableBorderSet using full Unicode box-drawing characters.
+func BoxBorderSet() TableBorderSet {
+	return TableBorderSet{
+		Top:            "─",
+		Bottom:         "─",
+		Left:           "│",
+		Right:          "│",
+		Header:         "─",
+		Row:            "─",
+		TopLeft:        "┌",
+		TopRight:       "┐",
+		BottomLeft:     "└",
+		BottomRight:    "┘",
+		TopJunction:    "┬",
+		BottomJunction: "┴",
+		LeftJunction:   "├",
+		RightJunction:  "┤",
+		Cross:          "┼",
+		HeaderLeft:     "├",
+		HeaderRight:    "┤",
+		HeaderCross:    "┼",
+		FooterLeft:     "├",
+		FooterRight:    "┤",
+		FooterCross:    "┼",
+	}
+}
+
+// MinimalBorderSet returns a TableBorderSet with no outer borders — only column
+// separators and a header underline.
+func MinimalBorderSet() TableBorderSet {
+	return TableBorderSet{
+		Left:        "",
+		Right:       "",
+		Header:      "─",
+		Row:         "─",
+		HeaderLeft:  "",
+		HeaderRight: "",
+		HeaderCross: "┼",
+		FooterLeft:  "",
+		FooterRight: "",
+		FooterCross: "┼",
+		Cross:       "┼",
+	}
 }
 
 // Default token values used by DefaultTheme and ThemeFromPalette.
@@ -86,6 +166,7 @@ const (
 	DefaultBlockquoteBar     = "│"
 	DefaultAlertBar          = "│"
 	DefaultCodeLineNumberSep = "│"
+	DefaultTableCellPad      = 1
 )
 
 // DefaultNestedBulletChars is the default set of bullet characters that

--- a/typography.go
+++ b/typography.go
@@ -361,6 +361,391 @@ func (t *Typography) Warning(text string) string { return t.Alert(AlertWarning, 
 func (t *Typography) Caution(text string) string { return t.Alert(AlertCaution, text) }
 
 // ---------------------------------------------------------------------------
+// Table
+// ---------------------------------------------------------------------------
+
+// Alignment represents the horizontal alignment of text within a table cell.
+type Alignment int
+
+const (
+	// AlignLeft aligns cell content to the left (default).
+	AlignLeft Alignment = iota
+	// AlignCenter centers cell content horizontally.
+	AlignCenter
+	// AlignRight aligns cell content to the right.
+	AlignRight
+)
+
+// TableOption is a functional option for per-table configuration.
+// It is distinct from Option, which configures the Typography instance.
+type TableOption func(*tableConfig)
+
+// CaptionPosition specifies where a table caption is rendered.
+type CaptionPosition int
+
+const (
+	// CaptionTop renders the caption above the table.
+	CaptionTop CaptionPosition = iota
+	// CaptionBottom renders the caption below the table.
+	CaptionBottom
+)
+
+// tableConfig holds per-table settings applied via TableOption.
+type tableConfig struct {
+	alignments      map[int]Alignment // column index -> alignment
+	rowSeparators   bool              // draw horizontal lines between body rows
+	stripedRows     bool              // alternate row styles for readability
+	caption         string            // optional caption text
+	captionPosition CaptionPosition   // top or bottom
+	footerRow       bool              // treat last row as a footer
+	maxColWidth     int               // global max column width (0 = unlimited)
+	maxColWidths    map[int]int       // per-column max widths (overrides global)
+}
+
+// WithColumnAlign sets the alignment for a specific column (0-indexed).
+// Columns without an explicit alignment default to AlignLeft.
+func WithColumnAlign(col int, align Alignment) TableOption {
+	return func(cfg *tableConfig) {
+		if cfg.alignments == nil {
+			cfg.alignments = make(map[int]Alignment)
+		}
+		cfg.alignments[col] = align
+	}
+}
+
+// WithRowSeparators enables horizontal separator lines between every body row.
+func WithRowSeparators(enabled bool) TableOption {
+	return func(cfg *tableConfig) {
+		cfg.rowSeparators = enabled
+	}
+}
+
+// WithStripedRows enables alternating row background styles for readability.
+// Odd body rows use the TableStripedCell style instead of TableCell.
+func WithStripedRows(enabled bool) TableOption {
+	return func(cfg *tableConfig) {
+		cfg.stripedRows = enabled
+	}
+}
+
+// WithCaption adds a caption above the table.
+func WithCaption(text string) TableOption {
+	return func(cfg *tableConfig) {
+		cfg.caption = text
+		cfg.captionPosition = CaptionTop
+	}
+}
+
+// WithCaptionBottom adds a caption below the table.
+func WithCaptionBottom(text string) TableOption {
+	return func(cfg *tableConfig) {
+		cfg.caption = text
+		cfg.captionPosition = CaptionBottom
+	}
+}
+
+// WithFooterRow treats the last row as a footer with a distinct separator
+// and the TableFooter style.
+func WithFooterRow(enabled bool) TableOption {
+	return func(cfg *tableConfig) {
+		cfg.footerRow = enabled
+	}
+}
+
+// WithMaxColumnWidth sets a global maximum visible width for all columns.
+// Cells exceeding this width are truncated with "…". A value of 0 disables
+// truncation. Per-column limits set via WithColumnMaxWidth take precedence.
+func WithMaxColumnWidth(n int) TableOption {
+	return func(cfg *tableConfig) {
+		cfg.maxColWidth = n
+	}
+}
+
+// WithColumnMaxWidth sets the maximum visible width for a specific column
+// (0-indexed). Cells exceeding this width are truncated with "…".
+// This overrides the global WithMaxColumnWidth for the given column.
+func WithColumnMaxWidth(col, n int) TableOption {
+	return func(cfg *tableConfig) {
+		if cfg.maxColWidths == nil {
+			cfg.maxColWidths = make(map[int]int)
+		}
+		cfg.maxColWidths[col] = n
+	}
+}
+
+// WithColumnAligns sets the alignment for columns 0, 1, 2, ... in order.
+// Columns beyond the length of the slice default to AlignLeft.
+func WithColumnAligns(aligns ...Alignment) TableOption {
+	return func(cfg *tableConfig) {
+		if cfg.alignments == nil {
+			cfg.alignments = make(map[int]Alignment)
+		}
+		for i, a := range aligns {
+			cfg.alignments[i] = a
+		}
+	}
+}
+
+// truncateCell truncates a string to maxWidth visible characters, appending "…"
+// if truncation occurs. Returns the original string if it fits.
+func truncateCell(s string, maxWidth int) string {
+	if maxWidth <= 0 || lipgloss.Width(s) <= maxWidth {
+		return s
+	}
+	runes := []rune(s)
+	// Reserve 1 character for the ellipsis.
+	for i := len(runes); i > 0; i-- {
+		candidate := string(runes[:i]) + "…"
+		if lipgloss.Width(candidate) <= maxWidth {
+			return candidate
+		}
+	}
+	return "…"
+}
+
+// truncateRows returns a copy of rows with cells truncated according to the
+// config's max column width settings. The original rows are not modified.
+func truncateRows(rows [][]string, cfg *tableConfig) [][]string {
+	if cfg.maxColWidth <= 0 && len(cfg.maxColWidths) == 0 {
+		return rows
+	}
+	out := make([][]string, len(rows))
+	for i, row := range rows {
+		newRow := make([]string, len(row))
+		for c, cell := range row {
+			maxW := cfg.maxColWidth
+			if w, ok := cfg.maxColWidths[c]; ok {
+				maxW = w
+			}
+			if maxW > 0 {
+				newRow[c] = truncateCell(cell, maxW)
+			} else {
+				newRow[c] = cell
+			}
+		}
+		out[i] = newRow
+	}
+	return out
+}
+
+// tableColumnWidths computes the maximum cell width per column across all rows.
+func tableColumnWidths(rows [][]string, cols int) []int {
+	widths := make([]int, cols)
+	for _, row := range rows {
+		for c := range cols {
+			cell := ""
+			if c < len(row) {
+				cell = row[c]
+			}
+			if w := lipgloss.Width(cell); w > widths[c] {
+				widths[c] = w
+			}
+		}
+	}
+	return widths
+}
+
+// tableHLine builds a horizontal separator line for a table.
+func (t *Typography) tableHLine(colWidths []int, pad int, left, fill, junction, right string) string {
+	segments := make([]string, len(colWidths))
+	for c, w := range colWidths {
+		segments[c] = strings.Repeat(fill, w+pad*2)
+	}
+	return t.theme.TableBorder.Render(left + strings.Join(segments, junction) + right)
+}
+
+// alignCell pads a rendered cell string to the given total width according to
+// the specified alignment. The returned string has exactly totalWidth visible
+// characters (excluding the surrounding padStr added by the caller).
+func alignCell(rendered string, cellWidth, totalWidth int, align Alignment) string {
+	gap := totalWidth - cellWidth
+	if gap <= 0 {
+		return rendered
+	}
+	switch align {
+	case AlignRight:
+		return strings.Repeat(" ", gap) + rendered
+	case AlignCenter:
+		left := gap / 2
+		right := gap - left
+		return strings.Repeat(" ", left) + rendered + strings.Repeat(" ", right)
+	default: // AlignLeft
+		return rendered + strings.Repeat(" ", gap)
+	}
+}
+
+// tableRow renders a single data row with cell content and vertical separators.
+func (t *Typography) tableRow(row []string, style lipgloss.Style, colWidths []int, padStr string, bordered bool, aligns map[int]Alignment) string {
+	bs := t.theme.TableBorderSet
+	cols := len(colWidths)
+	cells := make([]string, cols)
+	for c := range cols {
+		cell := ""
+		if c < len(row) {
+			cell = row[c]
+		}
+		rendered := style.Render(cell)
+		cellWidth := lipgloss.Width(cell)
+		align := AlignLeft
+		if a, ok := aligns[c]; ok {
+			align = a
+		}
+		cells[c] = padStr + alignCell(rendered, cellWidth, colWidths[c], align) + padStr
+	}
+
+	sep, end := "", ""
+	if bordered {
+		sep = t.theme.TableBorder.Render(bs.Left)
+		end = t.theme.TableBorder.Render(bs.Right)
+	}
+	inner := t.theme.TableBorder.Render("│")
+	return sep + strings.Join(cells, inner) + end
+}
+
+// Table renders a table from a slice of rows. The first row is treated as the
+// header. Each row is a slice of cell strings. Rows may have different lengths;
+// shorter rows are padded with empty cells. Returns an empty string if rows is
+// nil or empty.
+func (t *Typography) Table(rows [][]string) string {
+	return t.renderTable(rows, &tableConfig{})
+}
+
+// TableWithOpts renders a table like Table but accepts per-table options such
+// as column alignment. The first row is treated as the header.
+//
+//	t.TableWithOpts(rows,
+//	    herald.WithColumnAlign(0, herald.AlignCenter),
+//	    herald.WithColumnAlign(2, herald.AlignRight),
+//	)
+func (t *Typography) TableWithOpts(rows [][]string, opts ...TableOption) string {
+	cfg := &tableConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+	return t.renderTable(rows, cfg)
+}
+
+// tableMaxCols returns the maximum number of columns across all rows.
+func tableMaxCols(rows [][]string) int {
+	cols := 0
+	for _, row := range rows {
+		if len(row) > cols {
+			cols = len(row)
+		}
+	}
+	return cols
+}
+
+// renderTable is the shared implementation for Table and TableWithOpts.
+func (t *Typography) renderTable(rows [][]string, cfg *tableConfig) string {
+	if len(rows) == 0 {
+		return ""
+	}
+
+	cols := tableMaxCols(rows)
+	if cols == 0 {
+		return ""
+	}
+
+	// Apply auto-truncation before computing widths.
+	rows = truncateRows(rows, cfg)
+
+	aligns := cfg.alignments
+	if aligns == nil {
+		aligns = make(map[int]Alignment)
+	}
+
+	bs := t.theme.TableBorderSet
+	pad := t.theme.TableCellPad
+	padStr := strings.Repeat(" ", pad)
+	colWidths := tableColumnWidths(rows, cols)
+	bordered := bs.TopLeft != ""
+
+	// Determine body range and footer row.
+	bodyEnd := len(rows)
+	hasFooter := cfg.footerRow && len(rows) > 2
+	if hasFooter {
+		bodyEnd = len(rows) - 1
+	}
+
+	var sb strings.Builder
+
+	// Caption (top).
+	t.writeCaption(&sb, cfg, CaptionTop, false)
+
+	// Top border.
+	if bordered {
+		sb.WriteString(t.tableHLine(colWidths, pad, bs.TopLeft, bs.Top, bs.TopJunction, bs.TopRight))
+		sb.WriteByte('\n')
+	}
+
+	// Header row.
+	sb.WriteString(t.tableRow(rows[0], t.theme.TableHeader, colWidths, padStr, bordered, aligns))
+	sb.WriteByte('\n')
+	sb.WriteString(t.tableHLine(colWidths, pad, bs.HeaderLeft, bs.Header, bs.HeaderCross, bs.HeaderRight))
+
+	// Body rows.
+	hasRowSep := cfg.rowSeparators && bs.Row != ""
+	t.renderTableBody(rows[1:bodyEnd], &sb, colWidths, padStr, bordered, aligns, hasRowSep, cfg.stripedRows)
+
+	// Footer row.
+	if hasFooter {
+		sb.WriteByte('\n')
+		sb.WriteString(t.tableHLine(colWidths, pad, bs.FooterLeft, bs.Header, bs.FooterCross, bs.FooterRight))
+		sb.WriteByte('\n')
+		sb.WriteString(t.tableRow(rows[len(rows)-1], t.theme.TableFooter, colWidths, padStr, bordered, aligns))
+	}
+
+	// Bottom border.
+	if bordered {
+		sb.WriteByte('\n')
+		sb.WriteString(t.tableHLine(colWidths, pad, bs.BottomLeft, bs.Bottom, bs.BottomJunction, bs.BottomRight))
+	}
+
+	// Caption (bottom).
+	t.writeCaption(&sb, cfg, CaptionBottom, true)
+
+	return sb.String()
+}
+
+// writeCaption writes the table caption to the builder if it matches the
+// given position. When newlineBefore is true, a newline is prepended.
+func (t *Typography) writeCaption(sb *strings.Builder, cfg *tableConfig, pos CaptionPosition, newlineBefore bool) {
+	if cfg.caption == "" || cfg.captionPosition != pos {
+		return
+	}
+	if newlineBefore {
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(t.theme.TableCaption.Render(cfg.caption))
+	if !newlineBefore {
+		sb.WriteByte('\n')
+	}
+}
+
+// renderTableBody writes body rows to the builder, handling row separators and
+// striped row styling.
+func (t *Typography) renderTableBody(bodyRows [][]string, sb *strings.Builder, colWidths []int, padStr string, bordered bool, aligns map[int]Alignment, hasRowSep, striped bool) {
+	bs := t.theme.TableBorderSet
+	for i, row := range bodyRows {
+		sb.WriteByte('\n')
+		if hasRowSep && i > 0 {
+			left, right := bs.LeftJunction, bs.RightJunction
+			if !bordered {
+				left, right = "", ""
+			}
+			sb.WriteString(t.tableHLine(colWidths, t.theme.TableCellPad, left, bs.Row, bs.Cross, right))
+			sb.WriteByte('\n')
+		}
+		style := t.theme.TableCell
+		if striped && i%2 == 1 {
+			style = t.theme.TableStripedCell
+		}
+		sb.WriteString(t.tableRow(row, style, colWidths, padStr, bordered, aligns))
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Definition list
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `Table()` and `TableWithOpts()` methods for rendering tables in the terminal
- Two border presets: `BoxBorderSet()` (full Unicode box-drawing) and `MinimalBorderSet()` (no outer border)
- Per-table options via `TableOption`: column alignment, row separators, striped rows, captions (top/bottom), footer rows, and auto-truncation
- New theme fields: `TableHeader`, `TableCell`, `TableStripedCell`, `TableFooter`, `TableCaption`, `TableBorder`, `TableBorderSet`, `TableCellPad`
- Full functional options coverage (`WithTable*Style`, `WithTableBorderSet`, `WithTableCellPad`)