### PR TITLE
feat: add Ins/Del inline typography elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ fmt.Println(ty.DL([][2]string{
 | `Abbr(abbr, desc)`    | Abbreviation; `desc` is optional, appended in parentheses                                   |
 | `Sub(text)`           | Subscript, prefixed with `_`                                                                |
 | `Sup(text)`           | Superscript, prefixed with `^`                                                              |
+| `Ins(text)`           | Inserted text, prefixed with `+`                                                            |
+| `Del(text)`           | Deleted text, prefixed with `-`, strikethrough                                              |
 
 ```go
 fmt.Println(ty.Bold("important") + " and " + ty.Italic("nuanced"))
@@ -169,6 +171,8 @@ fmt.Println(ty.Kbd("Ctrl") + " + " + ty.Kbd("C"))
 fmt.Println(ty.Link("Go website", "https://go.dev"))
 fmt.Println(ty.Abbr("CSS", "Cascading Style Sheets"))
 fmt.Println(ty.Sub("2") + "O" + ty.Sup("n"))
+fmt.Println(ty.Ins("added line"))
+fmt.Println(ty.Del("removed line"))
 ```
 
 ```text
@@ -177,6 +181,8 @@ important and nuanced
 Go website (https://go.dev)
 CSS (Cascading Style Sheets)
 _2O^n
++added line
+-removed line
 ```
 
 ### Lists
@@ -430,6 +436,8 @@ ty := herald.New(
 | `WithLinkStyle`               | `Link`                  |
 | `WithKbdStyle`                | `Kbd`                   |
 | `WithAbbrStyle`               | `Abbr`                  |
+| `WithInsStyle`                | `Ins`                   |
+| `WithDelStyle`                | `Del`                   |
 | `WithListBulletStyle`         | Bullet/number marker    |
 | `WithListItemStyle`           | List item text          |
 | `WithDTStyle`                 | Definition term         |
@@ -457,6 +465,8 @@ ty := herald.New(
 | `WithHRChar(c)`                | `─`                | Character repeated for `HR`                                 |
 | `WithHRWidth(w)`               | `40`               | Width of `HR` in characters                                 |
 | `WithBlockquoteBar(c)`         | `│`                | Left bar character for `Blockquote`                         |
+| `WithInsPrefix(c)`             | `+`                | Prefix for `Ins` (inserted text)                            |
+| `WithDelPrefix(c)`             | `-`                | Prefix for `Del` (deleted text)                             |
 | `WithCodeLineNumbers(b)`       | `false`            | Show line numbers in `CodeBlock`                            |
 | `WithCodeLineNumberSep(c)`     | `│`                | Separator between line numbers and code                     |
 | `WithTableBorderSet(bs)`       | `BoxBorderSet()`   | Border character set (`BoxBorderSet` or `MinimalBorderSet`) |
@@ -533,9 +543,9 @@ ty := herald.New(
 | ----------- | ------------------------------------------------------------------------- |
 | `Primary`   | H1 headings                                                               |
 | `Secondary` | H2, list bullets                                                          |
-| `Tertiary`  | H3, links                                                                 |
+| `Tertiary`  | H3, links, `Ins`                                                          |
 | `Accent`    | H4, mark background                                                       |
-| `Highlight` | H5, `Abbr`                                                                |
+| `Highlight` | H5, `Abbr`, `Del`                                                         |
 | `Muted`     | H6, blockquote, HR, sub/sup, `DD`, line numbers, table border, caption    |
 | `Text`      | Body text, paragraphs, list items, inline code, `DT`, table cells, footer |
 | `Surface`   | Background for `Kbd`, striped table rows                                  |

--- a/examples/00_default-theme/main.go
+++ b/examples/00_default-theme/main.go
@@ -73,6 +73,8 @@ func main() {
 	fmt.Println(ty.Mark("Highlighted text"))
 	fmt.Println(ty.Kbd("Ctrl") + " + " + ty.Kbd("C"))
 	fmt.Println(ty.Sub("subscript") + " and " + ty.Sup("superscript"))
+	fmt.Println(ty.Ins("added line"))
+	fmt.Println(ty.Del("removed line"))
 	fmt.Println()
 
 	// Links & Abbreviations

--- a/examples/demos/hero/main.go
+++ b/examples/demos/hero/main.go
@@ -55,6 +55,7 @@ func main() {
 			ty.Kbd("Ctrl") + "+" + ty.Kbd("C") + "  " +
 			ty.Code("inline code"),
 	)
+	fmt.Println(ty.Ins("added") + "  " + ty.Del("removed"))
 	fmt.Println()
 
 	// Alert (just one)

--- a/examples/demos/inline/main.go
+++ b/examples/demos/inline/main.go
@@ -20,6 +20,8 @@ func main() {
 	fmt.Println(ty.Code("inline code"))
 	fmt.Println(ty.Kbd("Ctrl") + " + " + ty.Kbd("C"))
 	fmt.Println(ty.Sub("subscript") + " and " + ty.Sup("superscript"))
+	fmt.Println(ty.Ins("added line"))
+	fmt.Println(ty.Del("removed line"))
 	fmt.Println()
 
 	fmt.Println(ty.Link("https://go.dev"))

--- a/options.go
+++ b/options.go
@@ -126,6 +126,16 @@ func WithAbbrStyle(s lipgloss.Style) Option {
 	return func(ty *Typography) { ty.theme.Abbr = s }
 }
 
+// WithInsStyle overrides the inserted text style.
+func WithInsStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.Ins = s }
+}
+
+// WithDelStyle overrides the deleted text style.
+func WithDelStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.Del = s }
+}
+
 // --- List style options ---
 
 // WithListBulletStyle overrides the bullet/number marker style.
@@ -196,6 +206,16 @@ func WithHRWidth(w int) Option {
 // WithBlockquoteBar sets the left-bar character for blockquotes.
 func WithBlockquoteBar(c string) Option {
 	return func(ty *Typography) { ty.theme.BlockquoteBar = c }
+}
+
+// WithInsPrefix sets the prefix for inserted text.
+func WithInsPrefix(c string) Option {
+	return func(ty *Typography) { ty.theme.InsPrefix = c }
+}
+
+// WithDelPrefix sets the prefix for deleted text.
+func WithDelPrefix(c string) Option {
+	return func(ty *Typography) { ty.theme.DelPrefix = c }
 }
 
 // --- Nested list options ---

--- a/options_test.go
+++ b/options_test.go
@@ -88,6 +88,8 @@ func TestWithInlineStyles(t *testing.T) {
 		{"Link", WithLinkStyle(style)},
 		{"Kbd", WithKbdStyle(style)},
 		{"Abbr", WithAbbrStyle(style)},
+		{"Ins", WithInsStyle(style)},
+		{"Del", WithDelStyle(style)},
 	}
 
 	for _, tc := range tests {
@@ -158,6 +160,20 @@ func TestWithTokenOptions(t *testing.T) {
 		ty := New(WithBlockquoteBar("|"))
 		if ty.theme.BlockquoteBar != "|" {
 			t.Errorf("expected %q, got %q", "|", ty.theme.BlockquoteBar)
+		}
+	})
+
+	t.Run("InsPrefix", func(t *testing.T) {
+		ty := New(WithInsPrefix("++ "))
+		if ty.theme.InsPrefix != "++ " {
+			t.Errorf("expected %q, got %q", "++ ", ty.theme.InsPrefix)
+		}
+	})
+
+	t.Run("DelPrefix", func(t *testing.T) {
+		ty := New(WithDelPrefix("-- "))
+		if ty.theme.DelPrefix != "-- " {
+			t.Errorf("expected %q, got %q", "-- ", ty.theme.DelPrefix)
 		}
 	})
 }

--- a/palette.go
+++ b/palette.go
@@ -120,6 +120,13 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		Sup: lipgloss.NewStyle().
 			Foreground(p.Muted),
 
+		Ins: lipgloss.NewStyle().
+			Foreground(p.Tertiary),
+
+		Del: lipgloss.NewStyle().
+			Foreground(p.Highlight).
+			Strikethrough(true),
+
 		DT: lipgloss.NewStyle().
 			Bold(true).
 			Foreground(p.Text),
@@ -139,6 +146,8 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		HRChar:            DefaultHRChar,
 		HRWidth:           DefaultHRWidth,
 		BlockquoteBar:     DefaultBlockquoteBar,
+		InsPrefix:         DefaultInsPrefix,
+		DelPrefix:         DefaultDelPrefix,
 
 		CodeLineNumber:    lipgloss.NewStyle().Foreground(p.Muted).Background(p.Base),
 		CodeLineNumberSep: DefaultCodeLineNumberSep,

--- a/theme.go
+++ b/theme.go
@@ -40,6 +40,8 @@ type Theme struct {
 	Abbr          lipgloss.Style
 	Sub           lipgloss.Style
 	Sup           lipgloss.Style
+	Ins           lipgloss.Style
+	Del           lipgloss.Style
 
 	// Definition list
 	DT lipgloss.Style // definition term
@@ -67,6 +69,8 @@ type Theme struct {
 	HRChar              string   // character repeated for horizontal rules
 	HRWidth             int      // width of horizontal rule in characters
 	BlockquoteBar       string   // left-bar character for blockquotes
+	InsPrefix           string   // prefix for inserted text (e.g. "+")
+	DelPrefix           string   // prefix for deleted text (e.g. "-")
 
 	// Table elements
 	TableHeader      lipgloss.Style // style for header cell text (e.g. bold + primary color)
@@ -167,6 +171,8 @@ const (
 	DefaultAlertBar          = "│"
 	DefaultCodeLineNumberSep = "│"
 	DefaultTableCellPad      = 1
+	DefaultInsPrefix         = "+"
+	DefaultDelPrefix         = "-"
 )
 
 // DefaultNestedBulletChars is the default set of bullet characters that

--- a/typography.go
+++ b/typography.go
@@ -314,6 +314,16 @@ func (t *Typography) Sup(text string) string {
 	return t.theme.Sup.Render("^" + text)
 }
 
+// Ins renders inserted (added) text with a prefix marker.
+func (t *Typography) Ins(text string) string {
+	return t.theme.Ins.Render(t.theme.InsPrefix + text)
+}
+
+// Del renders deleted (removed) text with a prefix marker.
+func (t *Typography) Del(text string) string {
+	return t.theme.Del.Render(t.theme.DelPrefix + text)
+}
+
 // ---------------------------------------------------------------------------
 // Alerts
 // ---------------------------------------------------------------------------

--- a/typography_test.go
+++ b/typography_test.go
@@ -695,6 +695,53 @@ func TestSubSup(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Ins / Del
+// ---------------------------------------------------------------------------
+
+func TestInsDel(t *testing.T) {
+	ty := newTestTypography()
+
+	tests := []struct {
+		name     string
+		fn       func(string) string
+		text     string
+		contains string
+	}{
+		{"Ins basic", ty.Ins, "added line", "+added line"},
+		{"Del basic", ty.Del, "removed line", "-removed line"},
+		{"Ins empty", ty.Ins, "", "+"},
+		{"Del empty", ty.Del, "", "-"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := stripANSI(tc.fn(tc.text))
+			if !strings.Contains(result, tc.contains) {
+				t.Errorf("expected %q in %q", tc.contains, result)
+			}
+		})
+	}
+}
+
+func TestInsDelCustomPrefix(t *testing.T) {
+	ty := New(WithInsPrefix("++ "), WithDelPrefix("-- "))
+
+	t.Run("custom ins prefix", func(t *testing.T) {
+		result := stripANSI(ty.Ins("new"))
+		if !strings.Contains(result, "++ new") {
+			t.Errorf("expected '++ new' in %q", result)
+		}
+	})
+
+	t.Run("custom del prefix", func(t *testing.T) {
+		result := stripANSI(ty.Del("old"))
+		if !strings.Contains(result, "-- old") {
+			t.Errorf("expected '-- old' in %q", result)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Definition List
 // ---------------------------------------------------------------------------
 
@@ -813,6 +860,8 @@ func TestConcurrentAccess(t *testing.T) {
 			ty.Abbr("abbr", "description")
 			ty.Sub("sub")
 			ty.Sup("sup")
+			ty.Ins("added")
+			ty.Del("removed")
 			ty.DL([][2]string{{"term", "def"}})
 		}()
 	}


### PR DESCRIPTION
## Summary

- Add `Ins(text)` and `Del(text)` render methods for inline insertion/deletion markers (HTML `<ins>`/`<del>` analogue)
- Add `InsPrefix`/`DelPrefix` configurable tokens (default `+`/`-`)
- Add `WithInsStyle`, `WithDelStyle`, `WithInsPrefix`, `WithDelPrefix` functional options
- Palette integration: Ins -> Tertiary (green), Del -> Highlight (red) + strikethrough