### PR TITLE
feat: add Address and AddressCard block typography elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ fmt.Println(ty.H4("Subsection"))
 | `DL(pairs)`             | Definition list from `[][2]string` pairs (term, description)                  |
 | `DT(text)`              | Definition term (standalone)                                                  |
 | `DD(text)`              | Definition description (standalone)                                           |
+| `Address(text)`         | Contact/author block; renders multi-line text in a distinctive italic style   |
+| `AddressCard(text)`     | Bordered card variant of `Address` with rounded border                        |
 
 ```go
 fmt.Println(ty.Blockquote("First line.\nSecond line."))
@@ -137,6 +139,8 @@ fmt.Println(ty.DL([][2]string{
     {"Go", "A statically typed, compiled language"},
     {"Rust", "A systems programming language"},
 }))
+
+fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))
 ```
 
 ### Inline styles
@@ -442,6 +446,9 @@ ty := herald.New(
 | `WithListItemStyle`           | List item text          |
 | `WithDTStyle`                 | Definition term         |
 | `WithDDStyle`                 | Definition description  |
+| `WithAddressStyle`            | `Address`               |
+| `WithAddressCardStyle`        | `AddressCard` content   |
+| `WithAddressCardBorderStyle`  | `AddressCard` border    |
 | `WithTableHeaderStyle`        | Table header cells      |
 | `WithTableCellStyle`          | Table body cells        |
 | `WithTableStripedCellStyle`   | Alternating body rows   |
@@ -539,17 +546,17 @@ ty := herald.New(
 
 `ColorPalette` lets you define 9 colors and derive a complete theme from them. All style fields map from this palette; token options (characters, widths) are unaffected and retain their defaults. Alert colors are handled separately via `AlertPalette`.
 
-| Field       | Maps to                                                                   |
-| ----------- | ------------------------------------------------------------------------- |
-| `Primary`   | H1 headings                                                               |
-| `Secondary` | H2, list bullets                                                          |
-| `Tertiary`  | H3, links, `Ins`                                                          |
-| `Accent`    | H4, mark background                                                       |
-| `Highlight` | H5, `Abbr`, `Del`                                                         |
-| `Muted`     | H6, blockquote, HR, sub/sup, `DD`, line numbers, table border, caption    |
-| `Text`      | Body text, paragraphs, list items, inline code, `DT`, table cells, footer |
-| `Surface`   | Background for `Kbd`, striped table rows                                  |
-| `Base`      | Background for inline code, code blocks; mark fg                          |
+| Field       | Maps to                                                                                                               |
+| ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| `Primary`   | H1 headings                                                                                                           |
+| `Secondary` | H2, list bullets                                                                                                      |
+| `Tertiary`  | H3, links, `Ins`                                                                                                      |
+| `Accent`    | H4, mark background                                                                                                   |
+| `Highlight` | H5, `Abbr`, `Del`                                                                                                     |
+| `Muted`     | H6, blockquote, HR, sub/sup, `DD`, `Address`, `AddressCard`, `AddressCardBorder`, line numbers, table border, caption |
+| `Text`      | Body text, paragraphs, list items, inline code, `DT`, table cells, footer                                             |
+| `Surface`   | Background for `Kbd`, striped table rows                                                                              |
+| `Base`      | Background for inline code, code blocks; mark fg                                                                      |
 
 Pass the palette to `New()` via `WithPalette`, or call `ThemeFromPalette` to construct a `Theme` value directly.
 

--- a/examples/00_default-theme/main.go
+++ b/examples/00_default-theme/main.go
@@ -109,4 +109,12 @@ func main() {
 
 	fmt.Println(ty.DT("Manual Term"))
 	fmt.Println(ty.DD("Manual description using DT/DD directly"))
+	fmt.Println()
+
+	// Address
+	fmt.Println(ty.H3("Address"))
+	fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))
+	fmt.Println()
+	fmt.Println(ty.AddressCard("Jane Doe\njane@example.com\nSan Francisco, CA"))
+	fmt.Println()
 }

--- a/examples/demos/blocks/main.go
+++ b/examples/demos/blocks/main.go
@@ -34,4 +34,9 @@ func main() {
 
 	fmt.Println(ty.DT("Manual Term"))
 	fmt.Println(ty.DD("Manual description using DT/DD directly"))
+	fmt.Println()
+
+	fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))
+	fmt.Println()
+	fmt.Println(ty.AddressCard("Jane Doe\njane@example.com\nSan Francisco, CA"))
 }

--- a/options.go
+++ b/options.go
@@ -160,6 +160,23 @@ func WithDDStyle(s lipgloss.Style) Option {
 	return func(ty *Typography) { ty.theme.DD = s }
 }
 
+// --- Address style option ---
+
+// WithAddressStyle overrides the address/contact block style.
+func WithAddressStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.Address = s }
+}
+
+// WithAddressCardStyle overrides the address card content style.
+func WithAddressCardStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.AddressCard = s }
+}
+
+// WithAddressCardBorderStyle overrides the address card border style.
+func WithAddressCardBorderStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.AddressCardBorder = s }
+}
+
 // --- Heading decoration options ---
 
 // WithH1UnderlineChar sets the character used for the H1 underline.

--- a/options_test.go
+++ b/options_test.go
@@ -120,6 +120,33 @@ func TestWithDLStyles(t *testing.T) {
 	_ = ty
 }
 
+func TestWithAddressStyle(t *testing.T) {
+	style := lipgloss.NewStyle().Italic(true)
+	ty := New(WithAddressStyle(style))
+	result := ty.theme.Address.Render("test")
+	if result == "" {
+		t.Error("expected non-empty render from Address style")
+	}
+}
+
+func TestWithAddressCardStyle(t *testing.T) {
+	style := lipgloss.NewStyle().Italic(true)
+	ty := New(WithAddressCardStyle(style))
+	result := ty.theme.AddressCard.Render("test")
+	if result == "" {
+		t.Error("expected non-empty render from AddressCard style")
+	}
+}
+
+func TestWithAddressCardBorderStyle(t *testing.T) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+	ty := New(WithAddressCardBorderStyle(style))
+	result := ty.theme.AddressCardBorder.Render("test")
+	if result == "" {
+		t.Error("expected non-empty render from AddressCardBorder style")
+	}
+}
+
 func TestWithTokenOptions(t *testing.T) {
 	t.Run("BulletChar", func(t *testing.T) {
 		ty := New(WithBulletChar("*"))

--- a/palette.go
+++ b/palette.go
@@ -135,6 +135,17 @@ func ThemeFromPalette(p ColorPalette) Theme {
 			PaddingLeft(4).
 			Foreground(p.Muted),
 
+		Address: lipgloss.NewStyle().
+			Foreground(p.Muted).
+			Italic(true).
+			PaddingLeft(2),
+
+		AddressCard: lipgloss.NewStyle().
+			Foreground(p.Muted).
+			Italic(true),
+		AddressCardBorder: lipgloss.NewStyle().
+			Foreground(p.Muted),
+
 		H1UnderlineChar: DefaultH1UnderlineChar,
 		H2UnderlineChar: DefaultH2UnderlineChar,
 		H3UnderlineChar: DefaultH3UnderlineChar,

--- a/theme.go
+++ b/theme.go
@@ -47,6 +47,11 @@ type Theme struct {
 	DT lipgloss.Style // definition term
 	DD lipgloss.Style // definition description
 
+	// Address element
+	Address           lipgloss.Style // style for address/contact blocks
+	AddressCard       lipgloss.Style // content style for bordered address card
+	AddressCardBorder lipgloss.Style // border color/style for address card (same pattern as TableBorder)
+
 	// Callbacks
 	CodeFormatter func(code, language string) string // optional syntax highlighter
 

--- a/typography.go
+++ b/typography.go
@@ -782,3 +782,23 @@ func (t *Typography) DT(text string) string {
 func (t *Typography) DD(text string) string {
 	return t.theme.DD.Render(text)
 }
+
+// ---------------------------------------------------------------------------
+// Address
+// ---------------------------------------------------------------------------
+
+// Address renders a styled contact/author information block.
+func (t *Typography) Address(text string) string {
+	return t.theme.Address.Render(text)
+}
+
+// AddressCard renders a contact/author block inside a bordered card.
+// The border color is taken from the AddressCardBorder theme style.
+func (t *Typography) AddressCard(text string) string {
+	borderColor := t.theme.AddressCardBorder.GetForeground()
+	style := t.theme.AddressCard.
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		Padding(0, 1)
+	return style.Render(text)
+}

--- a/typography_test.go
+++ b/typography_test.go
@@ -810,6 +810,67 @@ func TestDTDD(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Address
+// ---------------------------------------------------------------------------
+
+func TestAddress(t *testing.T) {
+	ty := newTestTypography()
+
+	tests := []struct {
+		name     string
+		text     string
+		contains string
+	}{
+		{"basic", "Jane Doe", "Jane Doe"},
+		{"multi-line", "Jane Doe\njane@example.com\nSan Francisco, CA", "jane@example.com"},
+		{"empty", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := stripANSI(ty.Address(tc.text))
+			if tc.contains != "" && !strings.Contains(result, tc.contains) {
+				t.Errorf("Address: expected %q in %q", tc.contains, result)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AddressCard
+// ---------------------------------------------------------------------------
+
+func TestAddressCard(t *testing.T) {
+	ty := newTestTypography()
+
+	tests := []struct {
+		name     string
+		text     string
+		contains string
+	}{
+		{"basic", "Jane Doe", "Jane Doe"},
+		{"multi-line", "Jane Doe\njane@example.com\nSan Francisco, CA", "jane@example.com"},
+		{"empty", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := stripANSI(ty.AddressCard(tc.text))
+			if tc.contains != "" && !strings.Contains(result, tc.contains) {
+				t.Errorf("AddressCard: expected %q in %q", tc.contains, result)
+			}
+		})
+	}
+
+	t.Run("has rounded border characters", func(t *testing.T) {
+		result := stripANSI(ty.AddressCard("Test"))
+		if !strings.Contains(result, "\u256d") && !strings.Contains(result, "\u2570") {
+			t.Errorf("AddressCard should contain rounded border chars, got %q", result)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
 
@@ -863,6 +924,8 @@ func TestConcurrentAccess(t *testing.T) {
 			ty.Ins("added")
 			ty.Del("removed")
 			ty.DL([][2]string{{"term", "def"}})
+			ty.Address("Jane Doe\njane@example.com")
+			ty.AddressCard("Jane Doe\njane@example.com")
 		}()
 	}
 


### PR DESCRIPTION
## Summary

- Add `Address(text)` for styled contact/author blocks (HTML `<address>` analogue)
- Add `AddressCard(text)` bordered card variant with rounded border, using the same border/content style separation pattern as tables
- Add `WithAddressStyle`, `WithAddressCardStyle`, `WithAddressCardBorderStyle` functional options
- Palette integration: Muted foreground, italic; card border follows `TableBorder` color approach