### PR TITLE
feat: add Badge and Tag inline typography elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,22 +152,26 @@ fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))
 </p>
 </details>
 
-| Method                | Renders as                                                                                  |
-| --------------------- | ------------------------------------------------------------------------------------------- |
-| `Code(text, lang)`    | Inline code with background highlight; `lang` is optional, used when a CodeFormatter is set |
-| `Bold(text)`          | Bold                                                                                        |
-| `Italic(text)`        | Italic                                                                                      |
-| `Underline(text)`     | Underlined                                                                                  |
-| `Strikethrough(text)` | Strikethrough                                                                               |
-| `Small(text)`         | Faint                                                                                       |
-| `Mark(text)`          | Highlighted background                                                                      |
-| `Link(label, url)`    | Styled link; `url` is optional - when both differ, renders as `label (url)`                 |
-| `Kbd(text)`           | Keyboard key indicator                                                                      |
-| `Abbr(abbr, desc)`    | Abbreviation; `desc` is optional, appended in parentheses                                   |
-| `Sub(text)`           | Subscript, prefixed with `_`                                                                |
-| `Sup(text)`           | Superscript, prefixed with `^`                                                              |
-| `Ins(text)`           | Inserted text, prefixed with `+`                                                            |
-| `Del(text)`           | Deleted text, prefixed with `-`, strikethrough                                              |
+| Method                        | Renders as                                                                                  |
+| ----------------------------- | ------------------------------------------------------------------------------------------- |
+| `Code(text, lang)`            | Inline code with background highlight; `lang` is optional, used when a CodeFormatter is set |
+| `Bold(text)`                  | Bold                                                                                        |
+| `Italic(text)`                | Italic                                                                                      |
+| `Underline(text)`             | Underlined                                                                                  |
+| `Strikethrough(text)`         | Strikethrough                                                                               |
+| `Small(text)`                 | Faint                                                                                       |
+| `Mark(text)`                  | Highlighted background                                                                      |
+| `Link(label, url)`            | Styled link; `url` is optional - when both differ, renders as `label (url)`                 |
+| `Kbd(text)`                   | Keyboard key indicator                                                                      |
+| `Abbr(abbr, desc)`            | Abbreviation; `desc` is optional, appended in parentheses                                   |
+| `Sub(text)`                   | Subscript, prefixed with `_`                                                                |
+| `Sup(text)`                   | Superscript, prefixed with `^`                                                              |
+| `Ins(text)`                   | Inserted text, prefixed with `+`                                                            |
+| `Del(text)`                   | Deleted text, prefixed with `-`, strikethrough                                              |
+| `Badge(text)`                 | Styled pill/tag label (e.g. `[SUCCESS]`, `[BETA]`)                                          |
+| `BadgeWithStyle(text, style)` | Badge with a one-off style override for semantic variants                                   |
+| `Tag(text)`                   | Subtle pill/category label (lighter variant of Badge)                                       |
+| `TagWithStyle(text, style)`   | Tag with a one-off style override                                                           |
 
 ```go
 fmt.Println(ty.Bold("important") + " and " + ty.Italic("nuanced"))
@@ -177,6 +181,8 @@ fmt.Println(ty.Abbr("CSS", "Cascading Style Sheets"))
 fmt.Println(ty.Sub("2") + "O" + ty.Sup("n"))
 fmt.Println(ty.Ins("added line"))
 fmt.Println(ty.Del("removed line"))
+fmt.Println(ty.Badge("SUCCESS") + " " + ty.Badge("BETA"))
+fmt.Println(ty.Tag("v2.0") + " " + ty.Tag("go"))
 ```
 
 ```text
@@ -187,6 +193,8 @@ CSS (Cascading Style Sheets)
 _2O^n
 +added line
 -removed line
+SUCCESS  BETA
+v2.0  go
 ```
 
 ### Lists
@@ -442,6 +450,8 @@ ty := herald.New(
 | `WithAbbrStyle`               | `Abbr`                  |
 | `WithInsStyle`                | `Ins`                   |
 | `WithDelStyle`                | `Del`                   |
+| `WithBadgeStyle`              | `Badge`                 |
+| `WithTagStyle`                | `Tag`                   |
 | `WithListBulletStyle`         | Bullet/number marker    |
 | `WithListItemStyle`           | List item text          |
 | `WithDTStyle`                 | Definition term         |
@@ -549,14 +559,14 @@ ty := herald.New(
 | Field       | Maps to                                                                                                               |
 | ----------- | --------------------------------------------------------------------------------------------------------------------- |
 | `Primary`   | H1 headings                                                                                                           |
-| `Secondary` | H2, list bullets                                                                                                      |
+| `Secondary` | H2, list bullets, `Badge` background, `Tag` foreground                                                                |
 | `Tertiary`  | H3, links, `Ins`                                                                                                      |
 | `Accent`    | H4, mark background                                                                                                   |
 | `Highlight` | H5, `Abbr`, `Del`                                                                                                     |
 | `Muted`     | H6, blockquote, HR, sub/sup, `DD`, `Address`, `AddressCard`, `AddressCardBorder`, line numbers, table border, caption |
 | `Text`      | Body text, paragraphs, list items, inline code, `DT`, table cells, footer                                             |
-| `Surface`   | Background for `Kbd`, striped table rows                                                                              |
-| `Base`      | Background for inline code, code blocks; mark fg                                                                      |
+| `Surface`   | Background for `Kbd`, `Tag`, striped table rows                                                                       |
+| `Base`      | Background for inline code, code blocks; mark fg, `Badge` fg                                                          |
 
 Pass the palette to `New()` via `WithPalette`, or call `ThemeFromPalette` to construct a `Theme` value directly.
 

--- a/examples/00_default-theme/main.go
+++ b/examples/00_default-theme/main.go
@@ -117,4 +117,9 @@ func main() {
 	fmt.Println()
 	fmt.Println(ty.AddressCard("Jane Doe\njane@example.com\nSan Francisco, CA"))
 	fmt.Println()
+
+	// Badge / Tag
+	fmt.Println(ty.H3("Badge / Tag"))
+	fmt.Println(ty.Badge("SUCCESS") + " " + ty.Badge("BETA") + " " + ty.Tag("v2.0") + " " + ty.Tag("go"))
+	fmt.Println()
 }

--- a/examples/demos/hero/main.go
+++ b/examples/demos/hero/main.go
@@ -55,7 +55,7 @@ func main() {
 			ty.Kbd("Ctrl") + "+" + ty.Kbd("C") + "  " +
 			ty.Code("inline code"),
 	)
-	fmt.Println(ty.Ins("added") + "  " + ty.Del("removed"))
+	fmt.Println(ty.Ins("added") + "  " + ty.Del("removed") + "  " + ty.Badge("NEW") + "  " + ty.Tag("go"))
 	fmt.Println()
 
 	// Alert (just one)

--- a/examples/demos/inline/main.go
+++ b/examples/demos/inline/main.go
@@ -22,6 +22,7 @@ func main() {
 	fmt.Println(ty.Sub("subscript") + " and " + ty.Sup("superscript"))
 	fmt.Println(ty.Ins("added line"))
 	fmt.Println(ty.Del("removed line"))
+	fmt.Println(ty.Badge("SUCCESS") + " " + ty.Badge("BETA") + " " + ty.Tag("v2.0") + " " + ty.Tag("go"))
 	fmt.Println()
 
 	fmt.Println(ty.Link("https://go.dev"))

--- a/options.go
+++ b/options.go
@@ -177,6 +177,18 @@ func WithAddressCardBorderStyle(s lipgloss.Style) Option {
 	return func(ty *Typography) { ty.theme.AddressCardBorder = s }
 }
 
+// --- Badge / Tag style options ---
+
+// WithBadgeStyle overrides the badge/tag pill style.
+func WithBadgeStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.Badge = s }
+}
+
+// WithTagStyle overrides the tag/category label style.
+func WithTagStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.Tag = s }
+}
+
 // --- Heading decoration options ---
 
 // WithH1UnderlineChar sets the character used for the H1 underline.

--- a/options_test.go
+++ b/options_test.go
@@ -147,6 +147,24 @@ func TestWithAddressCardBorderStyle(t *testing.T) {
 	}
 }
 
+func TestWithBadgeStyle(t *testing.T) {
+	style := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#00FF00"))
+	ty := New(WithBadgeStyle(style))
+	result := ty.theme.Badge.Render("test")
+	if result == "" {
+		t.Error("expected non-empty render from Badge style")
+	}
+}
+
+func TestWithTagStyle(t *testing.T) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
+	ty := New(WithTagStyle(style))
+	result := ty.theme.Tag.Render("test")
+	if result == "" {
+		t.Error("expected non-empty render from Tag style")
+	}
+}
+
 func TestWithTokenOptions(t *testing.T) {
 	t.Run("BulletChar", func(t *testing.T) {
 		ty := New(WithBulletChar("*"))

--- a/palette.go
+++ b/palette.go
@@ -146,6 +146,17 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		AddressCardBorder: lipgloss.NewStyle().
 			Foreground(p.Muted),
 
+		Badge: lipgloss.NewStyle().
+			Background(p.Secondary).
+			Foreground(p.Base).
+			Bold(true).
+			Padding(0, 1),
+
+		Tag: lipgloss.NewStyle().
+			Foreground(p.Secondary).
+			Background(p.Surface).
+			Padding(0, 1),
+
 		H1UnderlineChar: DefaultH1UnderlineChar,
 		H2UnderlineChar: DefaultH2UnderlineChar,
 		H3UnderlineChar: DefaultH3UnderlineChar,

--- a/theme.go
+++ b/theme.go
@@ -52,6 +52,10 @@ type Theme struct {
 	AddressCard       lipgloss.Style // content style for bordered address card
 	AddressCardBorder lipgloss.Style // border color/style for address card (same pattern as TableBorder)
 
+	// Badge / Tag elements
+	Badge lipgloss.Style // style for bold pill/status labels
+	Tag   lipgloss.Style // style for subtle pill/category labels
+
 	// Callbacks
 	CodeFormatter func(code, language string) string // optional syntax highlighter
 

--- a/typography.go
+++ b/typography.go
@@ -802,3 +802,28 @@ func (t *Typography) AddressCard(text string) string {
 		Padding(0, 1)
 	return style.Render(text)
 }
+
+// ---------------------------------------------------------------------------
+// Badge
+// ---------------------------------------------------------------------------
+
+// Badge renders text as a styled pill/tag label.
+func (t *Typography) Badge(text string) string {
+	return t.theme.Badge.Render(text)
+}
+
+// BadgeWithStyle renders a badge using a one-off style override, useful for
+// semantic variants (success, warning, error) without changing the theme.
+func (t *Typography) BadgeWithStyle(text string, style lipgloss.Style) string {
+	return style.Render(text)
+}
+
+// Tag renders text as a subtle pill/category label.
+func (t *Typography) Tag(text string) string {
+	return t.theme.Tag.Render(text)
+}
+
+// TagWithStyle renders a tag using a one-off style override.
+func (t *Typography) TagWithStyle(text string, style lipgloss.Style) string {
+	return style.Render(text)
+}

--- a/typography_test.go
+++ b/typography_test.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"charm.land/lipgloss/v2"
 )
 
 // stripANSI removes all ANSI escape sequences from a string so that
@@ -871,6 +873,96 @@ func TestAddressCard(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Badge
+// ---------------------------------------------------------------------------
+
+func TestBadge(t *testing.T) {
+	ty := newTestTypography()
+
+	tests := []struct {
+		name     string
+		text     string
+		contains string
+	}{
+		{"basic", "SUCCESS", "SUCCESS"},
+		{"another label", "BETA", "BETA"},
+		{"empty", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := stripANSI(ty.Badge(tc.text))
+			if tc.contains != "" && !strings.Contains(result, tc.contains) {
+				t.Errorf("Badge: expected %q in %q", tc.contains, result)
+			}
+		})
+	}
+}
+
+func TestBadgeWithStyle(t *testing.T) {
+	ty := newTestTypography()
+	custom := lipgloss.NewStyle().Bold(true)
+
+	t.Run("one-off style override", func(t *testing.T) {
+		result := stripANSI(ty.BadgeWithStyle("OK", custom))
+		if !strings.Contains(result, "OK") {
+			t.Errorf("BadgeWithStyle: expected %q in %q", "OK", result)
+		}
+	})
+
+	t.Run("empty text", func(t *testing.T) {
+		result := ty.BadgeWithStyle("", custom)
+		// Should not panic; result may be empty or contain only ANSI codes.
+		_ = result
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Tag
+// ---------------------------------------------------------------------------
+
+func TestTag(t *testing.T) {
+	ty := newTestTypography()
+
+	tests := []struct {
+		name     string
+		text     string
+		contains string
+	}{
+		{"basic", "v2.0", "v2.0"},
+		{"another label", "go", "go"},
+		{"empty", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := stripANSI(ty.Tag(tc.text))
+			if tc.contains != "" && !strings.Contains(result, tc.contains) {
+				t.Errorf("Tag: expected %q in %q", tc.contains, result)
+			}
+		})
+	}
+}
+
+func TestTagWithStyle(t *testing.T) {
+	ty := newTestTypography()
+	custom := lipgloss.NewStyle().Italic(true)
+
+	t.Run("one-off style override", func(t *testing.T) {
+		result := stripANSI(ty.TagWithStyle("go", custom))
+		if !strings.Contains(result, "go") {
+			t.Errorf("TagWithStyle: expected %q in %q", "go", result)
+		}
+	})
+
+	t.Run("empty text", func(t *testing.T) {
+		result := ty.TagWithStyle("", custom)
+		// Should not panic; result may be empty or contain only ANSI codes.
+		_ = result
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
 
@@ -926,6 +1018,10 @@ func TestConcurrentAccess(t *testing.T) {
 			ty.DL([][2]string{{"term", "def"}})
 			ty.Address("Jane Doe\njane@example.com")
 			ty.AddressCard("Jane Doe\njane@example.com")
+			ty.Badge("SUCCESS")
+			ty.BadgeWithStyle("BETA", lipgloss.NewStyle().Bold(true))
+			ty.Tag("v2.0")
+			ty.TagWithStyle("go", lipgloss.NewStyle().Italic(true))
 		}()
 	}
 


### PR DESCRIPTION
## Summary

- Add `Badge(text)` and `BadgeWithStyle(text, style)` for bold status pill labels (e.g., `SUCCESS`, `ERROR`)
- Add `Tag(text)` and `TagWithStyle(text, style)` for subtle category labels (e.g., `v2.0`, `go`)
- Badge: bold, high-contrast (Bg Secondary, Fg Base). Tag: regular weight, lighter (Fg Secondary, Bg Surface)
- Both support one-off style overrides via `*WithStyle` for semantic variants without polluting the theme
- Add `WithBadgeStyle`, `WithTagStyle` functional options