### PR TITLE
feat: add Footnote typography element

### DIFF
--- a/examples/00_default-theme/main.go
+++ b/examples/00_default-theme/main.go
@@ -122,4 +122,13 @@ func main() {
 	fmt.Println(ty.H3("Badge / Tag"))
 	fmt.Println(ty.Badge("SUCCESS") + " " + ty.Badge("BETA") + " " + ty.Tag("v2.0") + " " + ty.Tag("go"))
 	fmt.Println()
+
+	// Footnote
+	fmt.Println(ty.H3("Footnote"))
+	fmt.Println(ty.P("Herald supports rich typography" + ty.FootnoteRef(1) + " with multiple elements" + ty.FootnoteRef(2)))
+	fmt.Println(ty.FootnoteSection([]string{
+		"Built on lipgloss v2",
+		"Headings, lists, alerts, and more",
+	}))
+	fmt.Println()
 }

--- a/examples/demos/blocks/main.go
+++ b/examples/demos/blocks/main.go
@@ -39,4 +39,12 @@ func main() {
 	fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))
 	fmt.Println()
 	fmt.Println(ty.AddressCard("Jane Doe\njane@example.com\nSan Francisco, CA"))
+	fmt.Println()
+
+	// Footnote section
+	fmt.Println(ty.P("Herald supports rich typography" + ty.FootnoteRef(1) + " with multiple elements" + ty.FootnoteRef(2)))
+	fmt.Println(ty.FootnoteSection([]string{
+		"Built on lipgloss v2",
+		"Headings, lists, alerts, and more",
+	}))
 }

--- a/footnote_test.go
+++ b/footnote_test.go
@@ -1,0 +1,128 @@
+package herald
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// FootnoteRef
+// ---------------------------------------------------------------------------
+
+func TestFootnoteRef(t *testing.T) {
+	ty := newTestTypography()
+
+	tests := []struct {
+		name     string
+		n        int
+		contains string
+	}{
+		{"ref 1", 1, "[1]"},
+		{"ref 99", 99, "[99]"},
+		{"ref 0", 0, "[0]"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := stripANSI(ty.FootnoteRef(tc.n))
+			if !strings.Contains(result, tc.contains) {
+				t.Errorf("FootnoteRef(%d): expected %q in %q", tc.n, tc.contains, result)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FootnoteSection
+// ---------------------------------------------------------------------------
+
+func TestFootnoteSection(t *testing.T) {
+	ty := newTestTypography()
+
+	t.Run("empty list returns empty string", func(t *testing.T) {
+		result := ty.FootnoteSection(nil)
+		if result != "" {
+			t.Errorf("FootnoteSection(nil) should be empty, got %q", result)
+		}
+	})
+
+	t.Run("empty slice returns empty string", func(t *testing.T) {
+		result := ty.FootnoteSection([]string{})
+		if result != "" {
+			t.Errorf("FootnoteSection([]) should be empty, got %q", result)
+		}
+	})
+
+	t.Run("single note", func(t *testing.T) {
+		result := stripANSI(ty.FootnoteSection([]string{"First note"}))
+		if !strings.Contains(result, "[1] First note") {
+			t.Errorf("expected '[1] First note' in %q", result)
+		}
+		// Verify divider is present
+		if !strings.Contains(result, strings.Repeat(DefaultFootnoteDividerChar, DefaultFootnoteDividerWidth)) {
+			t.Errorf("expected divider in %q", result)
+		}
+	})
+
+	t.Run("multiple notes", func(t *testing.T) {
+		notes := []string{"Built on lipgloss v2", "Headings, lists, alerts, and more"}
+		result := stripANSI(ty.FootnoteSection(notes))
+
+		if !strings.Contains(result, "[1] Built on lipgloss v2") {
+			t.Errorf("expected '[1] Built on lipgloss v2' in %q", result)
+		}
+		if !strings.Contains(result, "[2] Headings, lists, alerts, and more") {
+			t.Errorf("expected '[2] Headings, lists, alerts, and more' in %q", result)
+		}
+		// Verify divider is present
+		if !strings.Contains(result, strings.Repeat(DefaultFootnoteDividerChar, DefaultFootnoteDividerWidth)) {
+			t.Errorf("expected divider in %q", result)
+		}
+	})
+
+	t.Run("divider appears before notes", func(t *testing.T) {
+		result := stripANSI(ty.FootnoteSection([]string{"A note"}))
+		lines := strings.Split(result, "\n")
+		if len(lines) < 2 {
+			t.Fatalf("expected at least 2 lines, got %d", len(lines))
+		}
+		// First line should be the divider
+		if !strings.Contains(lines[0], strings.Repeat(DefaultFootnoteDividerChar, DefaultFootnoteDividerWidth)) {
+			t.Errorf("first line should be the divider, got %q", lines[0])
+		}
+		// Second line should be the note
+		if !strings.Contains(lines[1], "[1] A note") {
+			t.Errorf("second line should be the note, got %q", lines[1])
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// FootnoteCustomDivider
+// ---------------------------------------------------------------------------
+
+func TestFootnoteCustomDivider(t *testing.T) {
+	t.Run("custom char", func(t *testing.T) {
+		ty := New(WithFootnoteDividerChar("="))
+		result := stripANSI(ty.FootnoteSection([]string{"A note"}))
+		if !strings.Contains(result, strings.Repeat("=", DefaultFootnoteDividerWidth)) {
+			t.Errorf("expected custom divider char '=' in %q", result)
+		}
+	})
+
+	t.Run("custom width", func(t *testing.T) {
+		ty := New(WithFootnoteDividerWidth(10))
+		result := stripANSI(ty.FootnoteSection([]string{"A note"}))
+		if !strings.Contains(result, strings.Repeat(DefaultFootnoteDividerChar, 10)) {
+			t.Errorf("expected divider width 10 in %q", result)
+		}
+	})
+
+	t.Run("custom char and width", func(t *testing.T) {
+		ty := New(WithFootnoteDividerChar("*"), WithFootnoteDividerWidth(5))
+		result := stripANSI(ty.FootnoteSection([]string{"A note"}))
+		if !strings.Contains(result, "*****") {
+			t.Errorf("expected '*****' in %q", result)
+		}
+	})
+}

--- a/options.go
+++ b/options.go
@@ -189,6 +189,37 @@ func WithTagStyle(s lipgloss.Style) Option {
 	return func(ty *Typography) { ty.theme.Tag = s }
 }
 
+// --- Footnote style options ---
+
+// WithFootnoteRefStyle overrides the inline footnote reference marker style.
+func WithFootnoteRefStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.FootnoteRef = s }
+}
+
+// WithFootnoteItemStyle overrides the footnote item style.
+func WithFootnoteItemStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.FootnoteItem = s }
+}
+
+// WithFootnoteDividerStyle overrides the footnote divider style.
+func WithFootnoteDividerStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.FootnoteDivider = s }
+}
+
+// WithFootnoteDividerChar sets the character used for the footnote section divider.
+func WithFootnoteDividerChar(c string) Option {
+	return func(ty *Typography) { ty.theme.FootnoteDividerChar = c }
+}
+
+// WithFootnoteDividerWidth sets the width of the footnote section divider.
+func WithFootnoteDividerWidth(w int) Option {
+	return func(ty *Typography) {
+		if w > 0 {
+			ty.theme.FootnoteDividerWidth = w
+		}
+	}
+}
+
 // --- Heading decoration options ---
 
 // WithH1UnderlineChar sets the character used for the H1 underline.

--- a/options_test.go
+++ b/options_test.go
@@ -165,6 +165,33 @@ func TestWithTagStyle(t *testing.T) {
 	}
 }
 
+func TestWithFootnoteRefStyle(t *testing.T) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+	ty := New(WithFootnoteRefStyle(style))
+	result := ty.theme.FootnoteRef.Render("test")
+	if result == "" {
+		t.Error("expected non-empty render from FootnoteRef style")
+	}
+}
+
+func TestWithFootnoteItemStyle(t *testing.T) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
+	ty := New(WithFootnoteItemStyle(style))
+	result := ty.theme.FootnoteItem.Render("test")
+	if result == "" {
+		t.Error("expected non-empty render from FootnoteItem style")
+	}
+}
+
+func TestWithFootnoteDividerStyle(t *testing.T) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#0000FF"))
+	ty := New(WithFootnoteDividerStyle(style))
+	result := ty.theme.FootnoteDivider.Render("test")
+	if result == "" {
+		t.Error("expected non-empty render from FootnoteDivider style")
+	}
+}
+
 func TestWithTokenOptions(t *testing.T) {
 	t.Run("BulletChar", func(t *testing.T) {
 		ty := New(WithBulletChar("*"))
@@ -219,6 +246,34 @@ func TestWithTokenOptions(t *testing.T) {
 		ty := New(WithDelPrefix("-- "))
 		if ty.theme.DelPrefix != "-- " {
 			t.Errorf("expected %q, got %q", "-- ", ty.theme.DelPrefix)
+		}
+	})
+
+	t.Run("FootnoteDividerChar", func(t *testing.T) {
+		ty := New(WithFootnoteDividerChar("="))
+		if ty.theme.FootnoteDividerChar != "=" {
+			t.Errorf("expected %q, got %q", "=", ty.theme.FootnoteDividerChar)
+		}
+	})
+
+	t.Run("FootnoteDividerWidth positive", func(t *testing.T) {
+		ty := New(WithFootnoteDividerWidth(30))
+		if ty.theme.FootnoteDividerWidth != 30 {
+			t.Errorf("expected 30, got %d", ty.theme.FootnoteDividerWidth)
+		}
+	})
+
+	t.Run("FootnoteDividerWidth zero ignored", func(t *testing.T) {
+		ty := New(WithFootnoteDividerWidth(0))
+		if ty.theme.FootnoteDividerWidth != DefaultFootnoteDividerWidth {
+			t.Errorf("expected default %d, got %d", DefaultFootnoteDividerWidth, ty.theme.FootnoteDividerWidth)
+		}
+	})
+
+	t.Run("FootnoteDividerWidth negative ignored", func(t *testing.T) {
+		ty := New(WithFootnoteDividerWidth(-5))
+		if ty.theme.FootnoteDividerWidth != DefaultFootnoteDividerWidth {
+			t.Errorf("expected default %d, got %d", DefaultFootnoteDividerWidth, ty.theme.FootnoteDividerWidth)
 		}
 	})
 }

--- a/palette.go
+++ b/palette.go
@@ -157,19 +157,25 @@ func ThemeFromPalette(p ColorPalette) Theme {
 			Background(p.Surface).
 			Padding(0, 1),
 
+		FootnoteRef:     lipgloss.NewStyle().Foreground(p.Tertiary),
+		FootnoteItem:    lipgloss.NewStyle().Foreground(p.Muted),
+		FootnoteDivider: lipgloss.NewStyle().Foreground(p.Muted),
+
 		H1UnderlineChar: DefaultH1UnderlineChar,
 		H2UnderlineChar: DefaultH2UnderlineChar,
 		H3UnderlineChar: DefaultH3UnderlineChar,
 		HeadingBarChar:  DefaultHeadingBarChar,
 
-		BulletChar:        DefaultBulletChar,
-		NestedBulletChars: DefaultNestedBulletChars,
-		ListIndent:        DefaultListIndent,
-		HRChar:            DefaultHRChar,
-		HRWidth:           DefaultHRWidth,
-		BlockquoteBar:     DefaultBlockquoteBar,
-		InsPrefix:         DefaultInsPrefix,
-		DelPrefix:         DefaultDelPrefix,
+		BulletChar:           DefaultBulletChar,
+		NestedBulletChars:    DefaultNestedBulletChars,
+		ListIndent:           DefaultListIndent,
+		HRChar:               DefaultHRChar,
+		HRWidth:              DefaultHRWidth,
+		BlockquoteBar:        DefaultBlockquoteBar,
+		InsPrefix:            DefaultInsPrefix,
+		DelPrefix:            DefaultDelPrefix,
+		FootnoteDividerChar:  DefaultFootnoteDividerChar,
+		FootnoteDividerWidth: DefaultFootnoteDividerWidth,
 
 		CodeLineNumber:    lipgloss.NewStyle().Foreground(p.Muted).Background(p.Base),
 		CodeLineNumberSep: DefaultCodeLineNumberSep,

--- a/theme.go
+++ b/theme.go
@@ -56,6 +56,11 @@ type Theme struct {
 	Badge lipgloss.Style // style for bold pill/status labels
 	Tag   lipgloss.Style // style for subtle pill/category labels
 
+	// Footnote elements
+	FootnoteRef     lipgloss.Style // style for inline reference markers (e.g. "[1]")
+	FootnoteItem    lipgloss.Style // style for each footnote entry in the section
+	FootnoteDivider lipgloss.Style // style for the divider line above the footnote section
+
 	// Callbacks
 	CodeFormatter func(code, language string) string // optional syntax highlighter
 
@@ -71,15 +76,17 @@ type Theme struct {
 	ShowLineNumbers   bool           // whether to render line numbers in CodeBlock
 
 	// Configurable tokens
-	BulletChar          string   // character used for unordered list bullets
-	NestedBulletChars   []string // bullet chars cycling per depth for nested lists
-	ListIndent          int      // spaces per nesting level for nested lists
-	HierarchicalNumbers bool     // use hierarchical numbering (e.g. 2.1, 2.2) for nested OL
-	HRChar              string   // character repeated for horizontal rules
-	HRWidth             int      // width of horizontal rule in characters
-	BlockquoteBar       string   // left-bar character for blockquotes
-	InsPrefix           string   // prefix for inserted text (e.g. "+")
-	DelPrefix           string   // prefix for deleted text (e.g. "-")
+	BulletChar           string   // character used for unordered list bullets
+	NestedBulletChars    []string // bullet chars cycling per depth for nested lists
+	ListIndent           int      // spaces per nesting level for nested lists
+	HierarchicalNumbers  bool     // use hierarchical numbering (e.g. 2.1, 2.2) for nested OL
+	HRChar               string   // character repeated for horizontal rules
+	HRWidth              int      // width of horizontal rule in characters
+	BlockquoteBar        string   // left-bar character for blockquotes
+	InsPrefix            string   // prefix for inserted text (e.g. "+")
+	DelPrefix            string   // prefix for deleted text (e.g. "-")
+	FootnoteDividerChar  string   // character for footnote section divider (default "─")
+	FootnoteDividerWidth int      // width of footnote divider (default 20)
 
 	// Table elements
 	TableHeader      lipgloss.Style // style for header cell text (e.g. bold + primary color)
@@ -168,20 +175,22 @@ func MinimalBorderSet() TableBorderSet {
 
 // Default token values used by DefaultTheme and ThemeFromPalette.
 const (
-	DefaultH1UnderlineChar   = "═"
-	DefaultH2UnderlineChar   = "─"
-	DefaultH3UnderlineChar   = "·"
-	DefaultHeadingBarChar    = "▎"
-	DefaultBulletChar        = "•"
-	DefaultListIndent        = 2
-	DefaultHRChar            = "─"
-	DefaultHRWidth           = 40
-	DefaultBlockquoteBar     = "│"
-	DefaultAlertBar          = "│"
-	DefaultCodeLineNumberSep = "│"
-	DefaultTableCellPad      = 1
-	DefaultInsPrefix         = "+"
-	DefaultDelPrefix         = "-"
+	DefaultH1UnderlineChar      = "═"
+	DefaultH2UnderlineChar      = "─"
+	DefaultH3UnderlineChar      = "·"
+	DefaultHeadingBarChar       = "▎"
+	DefaultBulletChar           = "•"
+	DefaultListIndent           = 2
+	DefaultHRChar               = "─"
+	DefaultHRWidth              = 40
+	DefaultBlockquoteBar        = "│"
+	DefaultAlertBar             = "│"
+	DefaultCodeLineNumberSep    = "│"
+	DefaultTableCellPad         = 1
+	DefaultInsPrefix            = "+"
+	DefaultDelPrefix            = "-"
+	DefaultFootnoteDividerChar  = "─"
+	DefaultFootnoteDividerWidth = 20
 )
 
 // DefaultNestedBulletChars is the default set of bullet characters that

--- a/typography.go
+++ b/typography.go
@@ -827,3 +827,30 @@ func (t *Typography) Tag(text string) string {
 func (t *Typography) TagWithStyle(text string, style lipgloss.Style) string {
 	return style.Render(text)
 }
+
+// ---------------------------------------------------------------------------
+// Footnote
+// ---------------------------------------------------------------------------
+
+// FootnoteRef renders an inline footnote reference marker, e.g. "[1]".
+func (t *Typography) FootnoteRef(n int) string {
+	return t.theme.FootnoteRef.Render(fmt.Sprintf("[%d]", n))
+}
+
+// FootnoteSection renders the collected footnotes as a numbered list,
+// preceded by a divider line. Returns an empty string if notes is empty.
+func (t *Typography) FootnoteSection(notes []string) string {
+	if len(notes) == 0 {
+		return ""
+	}
+	divider := t.theme.FootnoteDivider.Render(
+		strings.Repeat(t.theme.FootnoteDividerChar, t.theme.FootnoteDividerWidth),
+	)
+	lines := make([]string, 0, len(notes)+1)
+	lines = append(lines, divider)
+	for i, note := range notes {
+		ref := fmt.Sprintf("[%d]", i+1)
+		lines = append(lines, t.theme.FootnoteItem.Render(ref+" "+note))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/typography_test.go
+++ b/typography_test.go
@@ -1022,6 +1022,8 @@ func TestConcurrentAccess(t *testing.T) {
 			ty.BadgeWithStyle("BETA", lipgloss.NewStyle().Bold(true))
 			ty.Tag("v2.0")
 			ty.TagWithStyle("go", lipgloss.NewStyle().Italic(true))
+			ty.FootnoteRef(1)
+			ty.FootnoteSection([]string{"note one", "note two"})
 		}()
 	}
 


### PR DESCRIPTION
## Summary

- Add `FootnoteRef(n)` for inline footnote reference markers (e.g. `[1]`)
- Add `FootnoteSection(notes)` for rendering a divider + numbered footnote list
- Footnotes compose with paragraphs via string concatenation, matching herald's existing inline pattern
- Add configurable tokens: `FootnoteDividerChar` (default `-`), `FootnoteDividerWidth` (default `20`)
- Add `WithFootnoteRefStyle`, `WithFootnoteItemStyle`, `WithFootnoteDividerStyle`, `WithFootnoteDividerChar`, `WithFootnoteDividerWidth` functional options
- Palette integration: Ref -> Tertiary, Item/Divider -> Muted