### PR TITLE
fix: separate blockquote bar style for visible rendering

### DIFF
--- a/examples/00_default-theme/main.go
+++ b/examples/00_default-theme/main.go
@@ -12,12 +12,12 @@ func main() {
 	ty := herald.New()
 
 	// Headings
-	fmt.Println(ty.H1("Heading 1 — Double Underline"))
-	fmt.Println(ty.H2("Heading 2 — Single Underline"))
-	fmt.Println(ty.H3("Heading 3 — Dotted Underline"))
-	fmt.Println(ty.H4("Heading 4 — Bar Prefix"))
-	fmt.Println(ty.H5("Heading 5 — Bar Prefix"))
-	fmt.Println(ty.H6("Heading 6 — Bar Prefix"))
+	fmt.Println(ty.H1("Heading 1 - Double Underline"))
+	fmt.Println(ty.H2("Heading 2 - Single Underline"))
+	fmt.Println(ty.H3("Heading 3 - Dotted Underline"))
+	fmt.Println(ty.H4("Heading 4 - Bar Prefix"))
+	fmt.Println(ty.H5("Heading 5 - Bar Prefix"))
+	fmt.Println(ty.H6("Heading 6 - Bar Prefix"))
 
 	// Block elements
 	fmt.Println(ty.P("This is a paragraph. It wraps text with the paragraph style."))

--- a/options.go
+++ b/options.go
@@ -64,6 +64,11 @@ func WithBlockquoteStyle(s lipgloss.Style) Option {
 	return func(ty *Typography) { ty.theme.Blockquote = s }
 }
 
+// WithBlockquoteBarStyle overrides the blockquote bar character style.
+func WithBlockquoteBarStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.BlockquoteBarStyle = s }
+}
+
 // WithCodeInlineStyle overrides the inline code style.
 func WithCodeInlineStyle(s lipgloss.Style) Option {
 	return func(ty *Typography) { ty.theme.CodeInline = s }

--- a/options_test.go
+++ b/options_test.go
@@ -192,6 +192,15 @@ func TestWithFootnoteDividerStyle(t *testing.T) {
 	}
 }
 
+func TestWithBlockquoteBarStyle(t *testing.T) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+	ty := New(WithBlockquoteBarStyle(style))
+	result := ty.theme.BlockquoteBarStyle.Render("│")
+	if result == "" {
+		t.Error("expected non-empty render from BlockquoteBarStyle")
+	}
+}
+
 func TestWithTokenOptions(t *testing.T) {
 	t.Run("BulletChar", func(t *testing.T) {
 		ty := New(WithBulletChar("*"))

--- a/palette.go
+++ b/palette.go
@@ -60,8 +60,11 @@ func ThemeFromPalette(p ColorPalette) Theme {
 
 		Blockquote: lipgloss.NewStyle().
 			Foreground(p.Muted).
-			Italic(true).
-			PaddingLeft(2),
+			Italic(true),
+
+		BlockquoteBarStyle: lipgloss.NewStyle().
+			Foreground(p.Muted).
+			PaddingLeft(1),
 
 		CodeInline: lipgloss.NewStyle().
 			Foreground(p.Text).

--- a/theme.go
+++ b/theme.go
@@ -18,11 +18,12 @@ type Theme struct {
 	H6 lipgloss.Style
 
 	// Text block elements
-	Paragraph  lipgloss.Style
-	Blockquote lipgloss.Style
-	CodeInline lipgloss.Style
-	CodeBlock  lipgloss.Style
-	HR         lipgloss.Style
+	Paragraph          lipgloss.Style
+	Blockquote         lipgloss.Style
+	BlockquoteBarStyle lipgloss.Style // style for the blockquote bar character(s)
+	CodeInline         lipgloss.Style
+	CodeBlock          lipgloss.Style
+	HR                 lipgloss.Style
 
 	// List elements
 	ListBullet lipgloss.Style // style for the bullet/number marker
@@ -175,15 +176,16 @@ func MinimalBorderSet() TableBorderSet {
 
 // Default token values used by DefaultTheme and ThemeFromPalette.
 const (
-	DefaultH1UnderlineChar      = "═"
-	DefaultH2UnderlineChar      = "─"
-	DefaultH3UnderlineChar      = "·"
-	DefaultHeadingBarChar       = "▎"
-	DefaultBulletChar           = "•"
-	DefaultListIndent           = 2
-	DefaultHRChar               = "─"
-	DefaultHRWidth              = 40
-	DefaultBlockquoteBar        = "│"
+	DefaultH1UnderlineChar = "═"
+	DefaultH2UnderlineChar = "─"
+	DefaultH3UnderlineChar = "·"
+	DefaultHeadingBarChar  = "▎"
+	DefaultBulletChar      = "•"
+	DefaultListIndent      = 2
+	DefaultHRChar          = "─"
+	DefaultHRWidth         = 40
+	DefaultBlockquoteBar   = "│"
+
 	DefaultAlertBar             = "│"
 	DefaultCodeLineNumberSep    = "│"
 	DefaultTableCellPad         = 1

--- a/typography.go
+++ b/typography.go
@@ -87,15 +87,16 @@ func (t *Typography) P(text string) string {
 }
 
 // Blockquote renders a blockquote with a left border bar. Multi-line text
-// is handled by prepending the bar to every line.
+// is handled by prepending the bar to every line. The bar is styled
+// separately from the text so it remains visually distinct.
 func (t *Typography) Blockquote(text string) string {
-	bar := t.theme.BlockquoteBar
+	bar := t.theme.BlockquoteBarStyle.Render(t.theme.BlockquoteBar)
 	lines := strings.Split(text, "\n")
 	quoted := make([]string, len(lines))
 	for i, line := range lines {
-		quoted[i] = bar + " " + line
+		quoted[i] = bar + " " + t.theme.Blockquote.Render(line)
 	}
-	return t.theme.Blockquote.Render(strings.Join(quoted, "\n"))
+	return strings.Join(quoted, "\n")
 }
 
 // UL renders an unordered (bulleted) list from the provided items.


### PR DESCRIPTION
##Summary

- Add `BlockquoteBarStyle` to render the blockquote bar separately from text, fixing bar visibility on dark backgrounds
- Add `WithBlockquoteBarStyle` functional option