### PR TITLE
feat: add HRWithLabel for labeled horizontal separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ fmt.Println(ty.H4("Subsection"))
 | `Blockquote(text)`       | Indented block with a left bar; supports multi-line input                     |
 | `CodeBlock(text, lang)`  | Fenced code block with padding; optional line numbers and syntax highlighting |
 | `HR()`                   | Horizontal rule, configurable width and character                             |
+| `HRWithLabel(label)`     | Horizontal rule with a centered label, e.g. `── Section ──`                   |
 | `DL(pairs)`              | Definition list from `[][2]string` pairs (term, description)                  |
 | `DT(text)`               | Definition term (standalone)                                                  |
 | `DD(text)`               | Definition description (standalone)                                           |
@@ -138,6 +139,7 @@ fmt.Println(ty.Blockquote("First line.\nSecond line."))
 
 fmt.Println(ty.CodeBlock("func main() {\n\tfmt.Println(\"hello\")\n}"))
 fmt.Println(ty.HR())
+fmt.Println(ty.HRWithLabel("Section"))
 
 fmt.Println(ty.DL([][2]string{
     {"Go", "A statically typed, compiled language"},
@@ -533,6 +535,7 @@ ty := herald.New(
 | `WithCodeInlineStyle`    | `Code`            |
 | `WithCodeBlockStyle`     | `CodeBlock`       |
 | `WithHRStyle`            | `HR`              |
+| `WithHRLabelStyle`       | `HRWithLabel`     |
 
 #### Inline
 
@@ -757,17 +760,17 @@ ty := herald.New(herald.WithTheme(herald.DraculaTheme()))
 
 `ColorPalette` lets you define 9 colors and derive a complete theme from them. All style fields map from this palette; token options (characters, widths) are unaffected and retain their defaults. Alert colors are handled separately via `AlertPalette`.
 
-| Field       | Maps to                                                                                                                                                  |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Primary`   | H1 headings                                                                                                                                              |
-| `Secondary` | H2, list bullets, `Badge` background, `Tag` foreground                                                                                                   |
-| `Tertiary`  | H3, links, `Ins`, `FootnoteRef`                                                                                                                          |
-| `Accent`    | H4, mark background                                                                                                                                      |
-| `Highlight` | H5, `Abbr`, `Del`                                                                                                                                        |
-| `Muted`     | H6, blockquote, HR, sub/sup, `DD`, `Address`, `AddressCard`, `AddressCardBorder`, `FootnoteItem`, `FootnoteDivider`, line numbers, table border, caption |
-| `Text`      | Body text, paragraphs, list items, inline code, `DT`, table cells, footer                                                                                |
-| `Surface`   | Background for `Kbd`, `Tag`, striped table rows                                                                                                          |
-| `Base`      | Background for inline code, code blocks; mark fg, `Badge` fg                                                                                             |
+| Field       | Maps to                                                                                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Primary`   | H1 headings                                                                                                                                                         |
+| `Secondary` | H2, list bullets, `Badge` background, `Tag` foreground                                                                                                              |
+| `Tertiary`  | H3, links, `Ins`, `FootnoteRef`                                                                                                                                     |
+| `Accent`    | H4, mark background                                                                                                                                                 |
+| `Highlight` | H5, `Abbr`, `Del`                                                                                                                                                   |
+| `Muted`     | H6, blockquote, HR, `HRLabel`, sub/sup, `DD`, `Address`, `AddressCard`, `AddressCardBorder`, `FootnoteItem`, `FootnoteDivider`, line numbers, table border, caption |
+| `Text`      | Body text, paragraphs, list items, inline code, `DT`, table cells, footer                                                                                           |
+| `Surface`   | Background for `Kbd`, `Tag`, striped table rows                                                                                                                     |
+| `Base`      | Background for inline code, code blocks; mark fg, `Badge` fg                                                                                                        |
 
 Pass the palette to `New()` via `WithPalette`, or call `ThemeFromPalette` to construct a `Theme` value directly.
 

--- a/examples/00_default-theme/main.go
+++ b/examples/00_default-theme/main.go
@@ -25,6 +25,7 @@ func main() {
 	fmt.Println()
 	fmt.Println(ty.CodeBlock("func main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
 	fmt.Println(ty.HR())
+	fmt.Println(ty.HRWithLabel("Section"))
 	fmt.Println()
 
 	// Lists

--- a/examples/demos/blocks/main.go
+++ b/examples/demos/blocks/main.go
@@ -23,6 +23,7 @@ func main() {
 	fmt.Println()
 
 	fmt.Println(ty.HR())
+	fmt.Println(ty.HRWithLabel("Section"))
 	fmt.Println()
 
 	fmt.Println(ty.DL([][2]string{

--- a/options.go
+++ b/options.go
@@ -84,6 +84,11 @@ func WithHRStyle(s lipgloss.Style) Option {
 	return func(ty *Typography) { ty.theme.HR = s }
 }
 
+// WithHRLabelStyle overrides the label style for labeled horizontal rules.
+func WithHRLabelStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.HRLabel = s }
+}
+
 // --- Inline style options ---
 
 // WithBoldStyle overrides the bold style.

--- a/options_test.go
+++ b/options_test.go
@@ -62,6 +62,7 @@ func TestWithBlockStyles(t *testing.T) {
 		{"CodeInline", WithCodeInlineStyle(style)},
 		{"CodeBlock", WithCodeBlockStyle(style)},
 		{"HR", WithHRStyle(style)},
+		{"HRLabel", WithHRLabelStyle(style)},
 	}
 
 	for _, tc := range tests {

--- a/palette.go
+++ b/palette.go
@@ -79,6 +79,9 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		HR: lipgloss.NewStyle().
 			Foreground(p.Muted),
 
+		HRLabel: lipgloss.NewStyle().
+			Foreground(p.Muted),
+
 		ListBullet: lipgloss.NewStyle().
 			Foreground(p.Secondary),
 

--- a/theme.go
+++ b/theme.go
@@ -24,6 +24,7 @@ type Theme struct {
 	CodeInline         lipgloss.Style
 	CodeBlock          lipgloss.Style
 	HR                 lipgloss.Style
+	HRLabel            lipgloss.Style // style for the label text within a labeled separator
 
 	// List elements
 	ListBullet lipgloss.Style // style for the bullet/number marker

--- a/typography.go
+++ b/typography.go
@@ -244,6 +244,27 @@ func (t *Typography) HR() string {
 	return t.theme.HR.Render(line)
 }
 
+// HRWithLabel renders a horizontal rule with a centered label.
+// The label is styled separately from the rule characters.
+// If label is empty, it falls back to a plain HR.
+func (t *Typography) HRWithLabel(label string) string {
+	if label == "" {
+		return t.HR()
+	}
+	labelWidth := lipgloss.Width(label)
+	totalWidth := t.theme.HRWidth
+	if labelWidth+4 > totalWidth {
+		// Label too long — just render it styled
+		return t.theme.HRLabel.Render(label)
+	}
+	remaining := totalWidth - labelWidth - 2 // 2 spaces around label
+	leftWidth := remaining / 2
+	rightWidth := remaining - leftWidth
+	left := strings.Repeat(t.theme.HRChar, leftWidth)
+	right := strings.Repeat(t.theme.HRChar, rightWidth)
+	return t.theme.HR.Render(left) + " " + t.theme.HRLabel.Render(label) + " " + t.theme.HR.Render(right)
+}
+
 // ---------------------------------------------------------------------------
 // Inline styles
 // ---------------------------------------------------------------------------

--- a/typography_test.go
+++ b/typography_test.go
@@ -562,6 +562,90 @@ func TestHRCustomWidth(t *testing.T) {
 	}
 }
 
+func TestHRWithLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		label    string
+		hrWidth  int
+		hrChar   string
+		wantHR   bool // true if we expect HR chars in output
+		wantText string
+	}{
+		{
+			name:     "basic label",
+			label:    "Section",
+			hrWidth:  40,
+			hrChar:   "-",
+			wantHR:   true,
+			wantText: "Section",
+		},
+		{
+			name:     "empty label falls back to HR",
+			label:    "",
+			hrWidth:  40,
+			hrChar:   "-",
+			wantHR:   true,
+			wantText: "",
+		},
+		{
+			name:     "label longer than width",
+			label:    "This is a very long label that exceeds the HR width",
+			hrWidth:  10,
+			hrChar:   "-",
+			wantHR:   false,
+			wantText: "This is a very long label that exceeds the HR width",
+		},
+		{
+			name:     "HR chars on both sides",
+			label:    "Mid",
+			hrWidth:  20,
+			hrChar:   "=",
+			wantHR:   true,
+			wantText: "Mid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ty := New(WithHRWidth(tc.hrWidth), WithHRChar(tc.hrChar))
+			result := stripANSI(ty.HRWithLabel(tc.label))
+
+			if tc.wantText != "" && !strings.Contains(result, tc.wantText) {
+				t.Errorf("expected result to contain %q, got %q", tc.wantText, result)
+			}
+
+			if tc.wantHR && !strings.Contains(result, tc.hrChar) {
+				t.Errorf("expected HR char %q in result, got %q", tc.hrChar, result)
+			}
+		})
+	}
+
+	t.Run("empty label matches HR output", func(t *testing.T) {
+		ty := New(WithHRWidth(20), WithHRChar("-"))
+		hrResult := stripANSI(ty.HR())
+		labelResult := stripANSI(ty.HRWithLabel(""))
+		if hrResult != labelResult {
+			t.Errorf("empty label should match HR(), got HR=%q, HRWithLabel=%q", hrResult, labelResult)
+		}
+	})
+
+	t.Run("HR chars appear on both sides of label", func(t *testing.T) {
+		ty := New(WithHRWidth(20), WithHRChar("-"))
+		result := stripANSI(ty.HRWithLabel("X"))
+		// Split around the label
+		parts := strings.SplitN(result, "X", 2)
+		if len(parts) != 2 {
+			t.Fatalf("expected label 'X' in result, got %q", result)
+		}
+		if !strings.Contains(parts[0], "-") {
+			t.Errorf("expected HR chars before label, got %q", parts[0])
+		}
+		if !strings.Contains(parts[1], "-") {
+			t.Errorf("expected HR chars after label, got %q", parts[1])
+		}
+	})
+}
+
 // ---------------------------------------------------------------------------
 // Inline styles
 // ---------------------------------------------------------------------------
@@ -1006,6 +1090,7 @@ func TestConcurrentAccess(t *testing.T) {
 			ty.OL("x", "y", "z")
 			ty.Bold("bold")
 			ty.HR()
+			ty.HRWithLabel("Section")
 			ty.Blockquote("quote")
 			ty.Code("code")
 			ty.CodeBlock("block")


### PR DESCRIPTION
## Summary

- Add `HRWithLabel(label)` render method for horizontal rules with centered text (e.g. `── Section ──`)
- Falls back to plain `HR()` when label is empty; renders just the label when it exceeds the rule width
- Add `HRLabel` theme style and `WithHRLabelStyle` functional option
- Palette: same Muted color as the rule line for visual cohesion