### PR TITLE
fix: guard against empty NestedBulletChars and protect default slice

### DIFF
--- a/list_test.go
+++ b/list_test.go
@@ -101,7 +101,7 @@ func TestNestUL(t *testing.T) {
 			t.Fatalf("expected 3 lines, got %d: %q", len(lines), result)
 		}
 		// Default bullets: "•", "◦", "▪", "▹"
-		bullets := DefaultNestedBulletChars
+		bullets := DefaultNestedBulletChars()
 		if !strings.Contains(lines[0], bullets[0]) {
 			t.Errorf("depth 0: expected bullet %q in %q", bullets[0], lines[0])
 		}
@@ -203,7 +203,7 @@ func TestMixedNesting(t *testing.T) {
 			t.Errorf("expected numbered parent, got %q", lines[0])
 		}
 		// Children should have bullet chars
-		if !strings.Contains(lines[1], DefaultNestedBulletChars[1]) {
+		if !strings.Contains(lines[1], DefaultNestedBulletChars()[1]) {
 			t.Errorf("expected bullet child, got %q", lines[1])
 		}
 	})

--- a/options_test.go
+++ b/options_test.go
@@ -357,7 +357,7 @@ func TestWithNestedBulletChars(t *testing.T) {
 
 	t.Run("empty slice ignored", func(t *testing.T) {
 		ty := New(WithNestedBulletChars([]string{}))
-		if len(ty.theme.NestedBulletChars) != len(DefaultNestedBulletChars) {
+		if len(ty.theme.NestedBulletChars) != len(DefaultNestedBulletChars()) {
 			t.Errorf("expected default chars to be preserved")
 		}
 	})

--- a/palette.go
+++ b/palette.go
@@ -173,7 +173,7 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		HeadingBarChar:  DefaultHeadingBarChar,
 
 		BulletChar:           DefaultBulletChar,
-		NestedBulletChars:    DefaultNestedBulletChars,
+		NestedBulletChars:    DefaultNestedBulletChars(),
 		ListIndent:           DefaultListIndent,
 		HRChar:               DefaultHRChar,
 		HRWidth:              DefaultHRWidth,

--- a/theme.go
+++ b/theme.go
@@ -196,9 +196,12 @@ const (
 	DefaultFootnoteDividerWidth = 20
 )
 
-// DefaultNestedBulletChars is the default set of bullet characters that
+// DefaultNestedBulletChars returns the default set of bullet characters that
 // cycle through nesting levels in nested unordered lists.
-var DefaultNestedBulletChars = []string{"•", "◦", "▪", "▹"}
+// A fresh slice is returned on each call to prevent mutation of shared state.
+func DefaultNestedBulletChars() []string {
+	return []string{"•", "◦", "▪", "▹"}
+}
 
 // hasDarkBG returns whether the terminal has a dark background.
 // It respects the HERALD_FORCE_DARK env var for tooling (e.g. screenshots).

--- a/typography.go
+++ b/typography.go
@@ -160,6 +160,9 @@ func (t *Typography) renderNestedList(items []ListItem, kind ListKind, depth int
 			childPrefix = num
 		} else {
 			chars := t.theme.NestedBulletChars
+			if len(chars) == 0 {
+				chars = []string{"•"}
+			}
 			bullet := chars[depth%len(chars)]
 			marker = t.theme.ListBullet.Render(bullet)
 			childPrefix = ""


### PR DESCRIPTION
## Summary

- Add a `len(chars) == 0` fallback in `renderNestedList` to prevent divide-by-zero panic when `Theme` is constructed directly with nil/empty `NestedBulletChars`.
- Convert `DefaultNestedBulletChars` from a package-level var to a function returning a fresh slice, preventing shared-state mutation.