### PR TITLE
fix: use display width for heading underlines and deduplicate style call

### DIFF
--- a/typography.go
+++ b/typography.go
@@ -37,8 +37,9 @@ func (t *Typography) Theme() Theme {
 // headingWithUnderline renders a heading with a repeated underline character
 // beneath the text. The underline matches the visible width of the text.
 func (t *Typography) headingWithUnderline(text string, style lipgloss.Style, char string) string {
-	rendered := style.UnsetMarginBottom().Render(text)
-	underline := style.UnsetMarginBottom().Render(strings.Repeat(char, len([]rune(text))))
+	noMargin := style.UnsetMarginBottom()
+	rendered := noMargin.Render(text)
+	underline := noMargin.Render(strings.Repeat(char, lipgloss.Width(text)))
 	return rendered + "\n" + underline + style.Render("")
 }
 


### PR DESCRIPTION
## Summary

Replace `len([]rune(text))` with `lipgloss.Width(text)` in `headingWithUnderline` so CJK and other wide characters produce correctly-aligned underlines.