### PR TITLE
refactor: cache terminal background detection and reduce option boilerplate

### DIFF
--- a/options.go
+++ b/options.go
@@ -365,13 +365,19 @@ func WithTableCellPad(n int) Option {
 
 // --- Alert options ---
 
+// ensureAlertConfig returns the AlertConfig for the given type,
+// initializing the map if needed.
+func ensureAlertConfig(ty *Typography, at AlertType) AlertConfig {
+	if ty.theme.Alerts == nil {
+		ty.theme.Alerts = make(map[AlertType]AlertConfig)
+	}
+	return ty.theme.Alerts[at]
+}
+
 // WithAlertStyle overrides the style for a specific alert type.
 func WithAlertStyle(at AlertType, s lipgloss.Style) Option {
 	return func(ty *Typography) {
-		if ty.theme.Alerts == nil {
-			ty.theme.Alerts = make(map[AlertType]AlertConfig)
-		}
-		cfg := ty.theme.Alerts[at]
+		cfg := ensureAlertConfig(ty, at)
 		cfg.Style = s
 		ty.theme.Alerts[at] = cfg
 	}
@@ -380,10 +386,7 @@ func WithAlertStyle(at AlertType, s lipgloss.Style) Option {
 // WithAlertIcon overrides the icon for a specific alert type.
 func WithAlertIcon(at AlertType, icon string) Option {
 	return func(ty *Typography) {
-		if ty.theme.Alerts == nil {
-			ty.theme.Alerts = make(map[AlertType]AlertConfig)
-		}
-		cfg := ty.theme.Alerts[at]
+		cfg := ensureAlertConfig(ty, at)
 		cfg.Icon = icon
 		ty.theme.Alerts[at] = cfg
 	}
@@ -392,10 +395,7 @@ func WithAlertIcon(at AlertType, icon string) Option {
 // WithAlertLabel overrides the label for a specific alert type.
 func WithAlertLabel(at AlertType, label string) Option {
 	return func(ty *Typography) {
-		if ty.theme.Alerts == nil {
-			ty.theme.Alerts = make(map[AlertType]AlertConfig)
-		}
-		cfg := ty.theme.Alerts[at]
+		cfg := ensureAlertConfig(ty, at)
 		cfg.Label = label
 		ty.theme.Alerts[at] = cfg
 	}

--- a/theme.go
+++ b/theme.go
@@ -2,6 +2,7 @@ package herald
 
 import (
 	"os"
+	"sync"
 
 	"charm.land/lipgloss/v2"
 )
@@ -200,13 +201,23 @@ const (
 // cycle through nesting levels in nested unordered lists.
 var DefaultNestedBulletChars = []string{"•", "◦", "▪", "▹"}
 
+var (
+	termBGOnce sync.Once
+	termBGDark bool
+)
+
 // hasDarkBG returns whether the terminal has a dark background.
-// It respects the HERALD_FORCE_DARK env var for tooling (e.g. screenshots).
+// The terminal query is cached to avoid repeated I/O, but the
+// HERALD_FORCE_DARK env var is always checked first so it can be
+// changed between calls (e.g. in tests).
 func hasDarkBG() bool {
 	if v := os.Getenv("HERALD_FORCE_DARK"); v != "" {
 		return v == "1" || v == "true"
 	}
-	return lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	termBGOnce.Do(func() {
+		termBGDark = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	})
+	return termBGDark
 }
 
 // DefaultTheme returns a Theme based on the Rose Pine color palette.

--- a/typography.go
+++ b/typography.go
@@ -105,9 +105,9 @@ func (t *Typography) UL(items ...string) string {
 		return ""
 	}
 	bullet := t.theme.BulletChar
+	marker := t.theme.ListBullet.Render(bullet)
 	lines := make([]string, len(items))
 	for i, item := range items {
-		marker := t.theme.ListBullet.Render(bullet)
 		lines[i] = marker + " " + t.theme.ListItem.Render(item)
 	}
 	return strings.Join(lines, "\n")
@@ -369,9 +369,10 @@ func (t *Typography) Alert(at AlertType, text string) string {
 
 	// Content: colored bar + unstyled text (matching GitHub alerts)
 	lines := strings.Split(text, "\n")
+	renderedBar := style.Render(bar)
 	content := make([]string, len(lines))
 	for i, line := range lines {
-		content[i] = style.Render(bar) + " " + line
+		content[i] = renderedBar + " " + line
 	}
 
 	return header + "\n" + strings.Join(content, "\n")


### PR DESCRIPTION
## Summary

- Cache `hasDarkBG()` terminal query with `sync.Once` while keeping `HERALD_FORCE_DARK` env var checked on every call.
- Extract `ensureAlertConfig()` helper to deduplicate nil-map init in `WithAlertStyle`, `WithAlertIcon`, and `WithAlertLabel`.