### PR TITLE
test: add direct tests for BoxBorderSet and DefaultAlertConfigs

### DIFF
--- a/alert_test.go
+++ b/alert_test.go
@@ -8,6 +8,49 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
+func TestDefaultAlertConfigs(t *testing.T) {
+	ap := AlertPalette{
+		Note:      lipgloss.Color("#0000FF"),
+		Tip:       lipgloss.Color("#00FF00"),
+		Important: lipgloss.Color("#800080"),
+		Warning:   lipgloss.Color("#FFFF00"),
+		Caution:   lipgloss.Color("#FF0000"),
+	}
+	configs := DefaultAlertConfigs(ap)
+
+	tests := []struct {
+		name  string
+		at    AlertType
+		icon  string
+		label string
+	}{
+		{"Note", AlertNote, DefaultAlertNoteIcon, DefaultAlertNoteLabel},
+		{"Tip", AlertTip, DefaultAlertTipIcon, DefaultAlertTipLabel},
+		{"Important", AlertImportant, DefaultAlertImportantIcon, DefaultAlertImportantLabel},
+		{"Warning", AlertWarning, DefaultAlertWarningIcon, DefaultAlertWarningLabel},
+		{"Caution", AlertCaution, DefaultAlertCautionIcon, DefaultAlertCautionLabel},
+	}
+
+	if len(configs) != 5 {
+		t.Fatalf("expected 5 configs, got %d", len(configs))
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, ok := configs[tc.at]
+			if !ok {
+				t.Fatalf("missing config for %s", tc.name)
+			}
+			if cfg.Icon != tc.icon {
+				t.Errorf("icon: got %q, want %q", cfg.Icon, tc.icon)
+			}
+			if cfg.Label != tc.label {
+				t.Errorf("label: got %q, want %q", cfg.Label, tc.label)
+			}
+		})
+	}
+}
+
 func TestAlertRendering(t *testing.T) {
 	ty := newTestTypography()
 

--- a/theme_test.go
+++ b/theme_test.go
@@ -62,6 +62,46 @@ func TestHasDarkBGEnvOverride(t *testing.T) {
 	})
 }
 
+func TestBoxBorderSet(t *testing.T) {
+	bs := BoxBorderSet()
+
+	fields := []struct {
+		name string
+		val  string
+		want string
+	}{
+		{"Top", bs.Top, "─"},
+		{"Bottom", bs.Bottom, "─"},
+		{"Left", bs.Left, "│"},
+		{"Right", bs.Right, "│"},
+		{"Header", bs.Header, "─"},
+		{"Row", bs.Row, "─"},
+		{"TopLeft", bs.TopLeft, "┌"},
+		{"TopRight", bs.TopRight, "┐"},
+		{"BottomLeft", bs.BottomLeft, "└"},
+		{"BottomRight", bs.BottomRight, "┘"},
+		{"TopJunction", bs.TopJunction, "┬"},
+		{"BottomJunction", bs.BottomJunction, "┴"},
+		{"LeftJunction", bs.LeftJunction, "├"},
+		{"RightJunction", bs.RightJunction, "┤"},
+		{"Cross", bs.Cross, "┼"},
+		{"HeaderLeft", bs.HeaderLeft, "├"},
+		{"HeaderRight", bs.HeaderRight, "┤"},
+		{"HeaderCross", bs.HeaderCross, "┼"},
+		{"FooterLeft", bs.FooterLeft, "├"},
+		{"FooterRight", bs.FooterRight, "┤"},
+		{"FooterCross", bs.FooterCross, "┼"},
+	}
+
+	for _, f := range fields {
+		t.Run(f.name, func(t *testing.T) {
+			if f.val != f.want {
+				t.Errorf("BoxBorderSet().%s = %q, want %q", f.name, f.val, f.want)
+			}
+		})
+	}
+}
+
 func TestDefaultThemeIdempotent(t *testing.T) {
 	t1 := DefaultTheme()
 	t2 := DefaultTheme()


### PR DESCRIPTION
## Summary

Verify all unicode characters in `BoxBorderSet` and all alert type `configs (icon, label)` returned by `DefaultAlertConfigs`.