### PR TITLE
fix: use TableBorderSet.ColumnSep instead of hardcoded pipe

### DIFF
--- a/theme.go
+++ b/theme.go
@@ -129,6 +129,7 @@ type TableBorderSet struct {
 	FooterLeft     string // footer-row left junction
 	FooterRight    string // footer-row right junction
 	FooterCross    string // footer-row interior junction
+	ColumnSep      string // vertical separator between columns (defaults to "│")
 }
 
 // BoxBorderSet returns a TableBorderSet using full Unicode box-drawing characters.
@@ -155,6 +156,7 @@ func BoxBorderSet() TableBorderSet {
 		FooterLeft:     "├",
 		FooterRight:    "┤",
 		FooterCross:    "┼",
+		ColumnSep:      "│",
 	}
 }
 
@@ -173,6 +175,7 @@ func MinimalBorderSet() TableBorderSet {
 		FooterRight: "",
 		FooterCross: "┼",
 		Cross:       "┼",
+		ColumnSep:   "│",
 	}
 }
 

--- a/theme_test.go
+++ b/theme_test.go
@@ -91,6 +91,7 @@ func TestBoxBorderSet(t *testing.T) {
 		{"FooterLeft", bs.FooterLeft, "├"},
 		{"FooterRight", bs.FooterRight, "┤"},
 		{"FooterCross", bs.FooterCross, "┼"},
+		{"ColumnSep", bs.ColumnSep, "│"},
 	}
 
 	for _, f := range fields {

--- a/typography.go
+++ b/typography.go
@@ -635,7 +635,11 @@ func (t *Typography) tableRow(row []string, style lipgloss.Style, colWidths []in
 		sep = t.theme.TableBorder.Render(bs.Left)
 		end = t.theme.TableBorder.Render(bs.Right)
 	}
-	inner := t.theme.TableBorder.Render("│")
+	colSep := bs.ColumnSep
+	if colSep == "" {
+		colSep = "│"
+	}
+	inner := t.theme.TableBorder.Render(colSep)
 	return sep + strings.Join(cells, inner) + end
 }
 


### PR DESCRIPTION
## Summary

Add ColumnSep field to TableBorderSet for the inner column separator. Falls back to "│" if empty for backwards compatibility with custom border sets that omit the field.