### PR TITLE
feat: add KV and KVGroup for key-value pair rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ fmt.Println(ty.H4("Subsection"))
 | `DL(pairs)`              | Definition list from `[][2]string` pairs (term, description)                  |
 | `DT(text)`               | Definition term (standalone)                                                  |
 | `DD(text)`               | Definition description (standalone)                                           |
+| `KV(key, value)`         | Key-value pair rendered as `key: value` with independent styling              |
+| `KVGroup(pairs)`         | Aligned key-value list from `[][2]string` pairs; keys are right-padded        |
 | `Address(text)`          | Contact/author block; renders multi-line text in a distinctive italic style   |
 | `AddressCard(text)`      | Bordered card variant of `Address` with rounded border                        |
 | `FootnoteRef(n)`         | Inline footnote reference marker, e.g. `[1]`                                  |
@@ -149,6 +151,15 @@ fmt.Println(ty.DL([][2]string{
 // Standalone terms and descriptions
 fmt.Println(ty.DT("Go"))
 fmt.Println(ty.DD("A statically typed, compiled language"))
+
+// Key-value pairs
+fmt.Println(ty.KV("Name", "Alice"))
+
+fmt.Println(ty.KVGroup([][2]string{
+    {"Name", "Alice"},
+    {"Role", "Admin"},
+    {"Status", "Active"},
+}))
 
 fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))
 
@@ -562,6 +573,13 @@ ty := herald.New(
 | `WithDTStyle`         | Definition term        |
 | `WithDDStyle`         | Definition description |
 
+#### Key-value
+
+| Option             | Targets                     |
+| ------------------ | --------------------------- |
+| `WithKVKeyStyle`   | `KV` / `KVGroup` key text   |
+| `WithKVValueStyle` | `KV` / `KVGroup` value text |
+
 #### Address
 
 | Option                       | Targets               |
@@ -646,6 +664,12 @@ ty := herald.New(
 | ------------------ | ------- | -------------------------------- |
 | `WithInsPrefix(c)` | `+`     | Prefix for `Ins` (inserted text) |
 | `WithDelPrefix(c)` | `-`     | Prefix for `Del` (deleted text)  |
+
+#### Key-value tokens
+
+| Option               | Default | Description                                       |
+| -------------------- | ------- | ------------------------------------------------- |
+| `WithKVSeparator(c)` | `:`     | Separator between key and value in `KV`/`KVGroup` |
 
 #### Table tokens
 
@@ -760,17 +784,17 @@ ty := herald.New(herald.WithTheme(herald.DraculaTheme()))
 
 `ColorPalette` lets you define 9 colors and derive a complete theme from them. All style fields map from this palette; token options (characters, widths) are unaffected and retain their defaults. Alert colors are handled separately via `AlertPalette`.
 
-| Field       | Maps to                                                                                                                                                             |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Primary`   | H1 headings                                                                                                                                                         |
-| `Secondary` | H2, list bullets, `Badge` background, `Tag` foreground                                                                                                              |
-| `Tertiary`  | H3, links, `Ins`, `FootnoteRef`                                                                                                                                     |
-| `Accent`    | H4, mark background                                                                                                                                                 |
-| `Highlight` | H5, `Abbr`, `Del`                                                                                                                                                   |
-| `Muted`     | H6, blockquote, HR, `HRLabel`, sub/sup, `DD`, `Address`, `AddressCard`, `AddressCardBorder`, `FootnoteItem`, `FootnoteDivider`, line numbers, table border, caption |
-| `Text`      | Body text, paragraphs, list items, inline code, `DT`, table cells, footer                                                                                           |
-| `Surface`   | Background for `Kbd`, `Tag`, striped table rows                                                                                                                     |
-| `Base`      | Background for inline code, code blocks; mark fg, `Badge` fg                                                                                                        |
+| Field       | Maps to                                                                                                                                                                      |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Primary`   | H1 headings                                                                                                                                                                  |
+| `Secondary` | H2, list bullets, `Badge` background, `Tag` foreground                                                                                                                       |
+| `Tertiary`  | H3, links, `Ins`, `FootnoteRef`                                                                                                                                              |
+| `Accent`    | H4, mark background                                                                                                                                                          |
+| `Highlight` | H5, `Abbr`, `Del`                                                                                                                                                            |
+| `Muted`     | H6, blockquote, HR, `HRLabel`, sub/sup, `DD`, `KVKey`, `Address`, `AddressCard`, `AddressCardBorder`, `FootnoteItem`, `FootnoteDivider`, line numbers, table border, caption |
+| `Text`      | Body text, paragraphs, list items, inline code, `DT`, `KVValue`, table cells, footer                                                                                         |
+| `Surface`   | Background for `Kbd`, `Tag`, striped table rows                                                                                                                              |
+| `Base`      | Background for inline code, code blocks; mark fg, `Badge` fg                                                                                                                 |
 
 Pass the palette to `New()` via `WithPalette`, or call `ThemeFromPalette` to construct a `Theme` value directly.
 

--- a/examples/00_default-theme/main.go
+++ b/examples/00_default-theme/main.go
@@ -112,6 +112,17 @@ func main() {
 	fmt.Println(ty.DD("Manual description using DT/DD directly"))
 	fmt.Println()
 
+	// Key-Value
+	fmt.Println(ty.H3("Key-Value"))
+	fmt.Println(ty.KV("Name", "Alice"))
+	fmt.Println()
+	fmt.Println(ty.KVGroup([][2]string{
+		{"Name", "Alice"},
+		{"Role", "Admin"},
+		{"Status", "Active"},
+	}))
+	fmt.Println()
+
 	// Address
 	fmt.Println(ty.H3("Address"))
 	fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))

--- a/examples/demos/blocks/main.go
+++ b/examples/demos/blocks/main.go
@@ -37,6 +37,16 @@ func main() {
 	fmt.Println(ty.DD("Manual description using DT/DD directly"))
 	fmt.Println()
 
+	// Key-Value
+	fmt.Println(ty.KV("Name", "Alice"))
+	fmt.Println()
+	fmt.Println(ty.KVGroup([][2]string{
+		{"Name", "Alice"},
+		{"Role", "Admin"},
+		{"Status", "Active"},
+	}))
+	fmt.Println()
+
 	fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))
 	fmt.Println()
 	fmt.Println(ty.AddressCard("Jane Doe\njane@example.com\nSan Francisco, CA"))

--- a/options.go
+++ b/options.go
@@ -170,6 +170,23 @@ func WithDDStyle(s lipgloss.Style) Option {
 	return func(ty *Typography) { ty.theme.DD = s }
 }
 
+// --- Key-value style options ---
+
+// WithKVKeyStyle overrides the key style for key-value pairs.
+func WithKVKeyStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.KVKey = s }
+}
+
+// WithKVValueStyle overrides the value style for key-value pairs.
+func WithKVValueStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.KVValue = s }
+}
+
+// WithKVSeparator sets the separator between key and value (default ":").
+func WithKVSeparator(s string) Option {
+	return func(ty *Typography) { ty.theme.KVSeparator = s }
+}
+
 // --- Address style option ---
 
 // WithAddressStyle overrides the address/contact block style.

--- a/options_test.go
+++ b/options_test.go
@@ -136,6 +136,33 @@ func TestWithDLStyles(t *testing.T) {
 	}
 }
 
+func TestWithKVStyles(t *testing.T) {
+	t.Run("KVKeyStyle", func(t *testing.T) {
+		style := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FF0000"))
+		ty := New(WithKVKeyStyle(style))
+		result := ty.theme.KVKey.Render("test")
+		if result == "" {
+			t.Error("expected non-empty render from KVKey style")
+		}
+	})
+
+	t.Run("KVValueStyle", func(t *testing.T) {
+		style := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
+		ty := New(WithKVValueStyle(style))
+		result := ty.theme.KVValue.Render("test")
+		if result == "" {
+			t.Error("expected non-empty render from KVValue style")
+		}
+	})
+
+	t.Run("KVSeparator", func(t *testing.T) {
+		ty := New(WithKVSeparator(" =>"))
+		if ty.theme.KVSeparator != " =>" {
+			t.Errorf("expected %q, got %q", " =>", ty.theme.KVSeparator)
+		}
+	})
+}
+
 func TestWithAddressStyle(t *testing.T) {
 	style := lipgloss.NewStyle().Italic(true)
 	ty := New(WithAddressStyle(style))

--- a/palette.go
+++ b/palette.go
@@ -141,6 +141,13 @@ func ThemeFromPalette(p ColorPalette) Theme {
 			PaddingLeft(4).
 			Foreground(p.Muted),
 
+		KVKey: lipgloss.NewStyle().
+			Foreground(p.Muted).
+			Bold(true),
+		KVValue: lipgloss.NewStyle().
+			Foreground(p.Text),
+		KVSeparator: DefaultKVSeparator,
+
 		Address: lipgloss.NewStyle().
 			Foreground(p.Muted).
 			Italic(true).

--- a/theme.go
+++ b/theme.go
@@ -50,6 +50,11 @@ type Theme struct {
 	DT lipgloss.Style // definition term
 	DD lipgloss.Style // definition description
 
+	// Key-value elements
+	KVKey       lipgloss.Style // style for key text in key-value pairs
+	KVValue     lipgloss.Style // style for value text in key-value pairs
+	KVSeparator string         // separator between key and value (default ":")
+
 	// Address element
 	Address           lipgloss.Style // style for address/contact blocks
 	AddressCard       lipgloss.Style // content style for bordered address card
@@ -198,6 +203,7 @@ const (
 	DefaultDelPrefix            = "-"
 	DefaultFootnoteDividerChar  = "─"
 	DefaultFootnoteDividerWidth = 20
+	DefaultKVSeparator          = ":"
 	MaxWidthChars               = 500
 )
 

--- a/typography.go
+++ b/typography.go
@@ -817,6 +817,39 @@ func (t *Typography) DD(text string) string {
 }
 
 // ---------------------------------------------------------------------------
+// Key-value pairs
+// ---------------------------------------------------------------------------
+
+// KV renders a single key-value pair as "key: value" with the key and value
+// styled independently. The separator is taken from the theme's KVSeparator.
+func (t *Typography) KV(key, value string) string {
+	return t.theme.KVKey.Render(key+t.theme.KVSeparator) + " " + t.theme.KVValue.Render(value)
+}
+
+// KVGroup renders multiple key-value pairs with keys right-padded so that
+// values align vertically. Each pair is a two-element array [key, value].
+// Returns an empty string for empty input.
+func (t *Typography) KVGroup(pairs [][2]string) string {
+	if len(pairs) == 0 {
+		return ""
+	}
+	// Find max key width for alignment.
+	maxKeyWidth := 0
+	for _, pair := range pairs {
+		if w := lipgloss.Width(pair[0]); w > maxKeyWidth {
+			maxKeyWidth = w
+		}
+	}
+	lines := make([]string, len(pairs))
+	for i, pair := range pairs {
+		keyWidth := lipgloss.Width(pair[0])
+		padding := strings.Repeat(" ", maxKeyWidth-keyWidth)
+		lines[i] = t.theme.KVKey.Render(pair[0]+padding+t.theme.KVSeparator) + " " + t.theme.KVValue.Render(pair[1])
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ---------------------------------------------------------------------------
 // Address
 // ---------------------------------------------------------------------------
 

--- a/typography_test.go
+++ b/typography_test.go
@@ -1074,6 +1074,115 @@ func TestVeryLongText(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Key-value pairs
+// ---------------------------------------------------------------------------
+
+func TestKV(t *testing.T) {
+	ty := newTestTypography()
+
+	t.Run("basic pair", func(t *testing.T) {
+		got := stripANSI(ty.KV("Name", "Alice"))
+		if got != "Name: Alice" {
+			t.Errorf("KV basic pair = %q, want %q", got, "Name: Alice")
+		}
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		got := stripANSI(ty.KV("", "value"))
+		if got != ": value" {
+			t.Errorf("KV empty key = %q, want %q", got, ": value")
+		}
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		got := stripANSI(ty.KV("Key", ""))
+		if got != "Key: " {
+			t.Errorf("KV empty value = %q, want %q", got, "Key: ")
+		}
+	})
+
+	t.Run("custom separator", func(t *testing.T) {
+		ty2 := New(WithKVSeparator(" →"))
+		got := stripANSI(ty2.KV("Name", "Alice"))
+		if got != "Name → Alice" {
+			t.Errorf("KV custom sep = %q, want %q", got, "Name → Alice")
+		}
+	})
+
+	t.Run("custom styles", func(t *testing.T) {
+		ty2 := New(
+			WithKVKeyStyle(lipgloss.NewStyle().Bold(true)),
+			WithKVValueStyle(lipgloss.NewStyle().Italic(true)),
+		)
+		got := ty2.KV("Name", "Alice")
+		if got == "" {
+			t.Error("KV custom styles returned empty string")
+		}
+	})
+}
+
+func TestKVGroup(t *testing.T) {
+	ty := newTestTypography()
+
+	t.Run("empty input", func(t *testing.T) {
+		got := ty.KVGroup(nil)
+		if got != "" {
+			t.Errorf("KVGroup empty = %q, want empty", got)
+		}
+	})
+
+	t.Run("single pair", func(t *testing.T) {
+		got := stripANSI(ty.KVGroup([][2]string{{"Name", "Alice"}}))
+		if got != "Name: Alice" {
+			t.Errorf("KVGroup single = %q, want %q", got, "Name: Alice")
+		}
+	})
+
+	t.Run("multiple pairs aligned", func(t *testing.T) {
+		pairs := [][2]string{
+			{"Name", "Alice"},
+			{"Age", "30"},
+			{"Location", "Wonderland"},
+		}
+		got := stripANSI(ty.KVGroup(pairs))
+		lines := strings.Split(got, "\n")
+		if len(lines) != 3 {
+			t.Fatalf("KVGroup lines = %d, want 3", len(lines))
+		}
+		// All colons should be at the same position (after "Location" length = 8).
+		for i, line := range lines {
+			idx := strings.Index(line, ":")
+			if idx != 8 {
+				t.Errorf("line %d colon at %d, want 8: %q", i, idx, line)
+			}
+		}
+	})
+
+	t.Run("empty key in group", func(t *testing.T) {
+		pairs := [][2]string{
+			{"Name", "Alice"},
+			{"", "orphan"},
+		}
+		got := stripANSI(ty.KVGroup(pairs))
+		if !strings.Contains(got, "orphan") {
+			t.Errorf("KVGroup should contain orphan value, got %q", got)
+		}
+	})
+
+	t.Run("custom separator in group", func(t *testing.T) {
+		ty2 := New(WithKVSeparator(" ="))
+		pairs := [][2]string{
+			{"host", "localhost"},
+			{"port", "8080"},
+		}
+		got := stripANSI(ty2.KVGroup(pairs))
+		if !strings.Contains(got, "=") {
+			t.Errorf("KVGroup custom sep should contain '=', got %q", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Concurrency safety (for -race detector)
 // ---------------------------------------------------------------------------
 
@@ -1109,6 +1218,8 @@ func TestConcurrentAccess(t *testing.T) {
 			ty.TagWithStyle("go", lipgloss.NewStyle().Italic(true))
 			ty.FootnoteRef(1)
 			ty.FootnoteSection([]string{"note one", "note two"})
+			ty.KV("key", "value")
+			ty.KVGroup([][2]string{{"a", "1"}, {"bb", "2"}})
 		}()
 	}
 


### PR DESCRIPTION
 ## Summary

- Add `KV(key, value)` for single key-value pairs and `KVGroup(pairs)` for aligned multi-pair output
- KVGroup right-pads keys to align all values in a column
- Add `KVKey`, `KVValue` theme styles and `KVSeparator` token (default `:`)
- Add `WithKVKeyStyle`, `WithKVValueStyle`, `WithKVSeparator` functional options
- Palette: key -> Muted + Bold (faint label), value -> Text (clear readout) - inverse of DL/DT for visual distinction