### PR TITLE
feat: add semantic palette with themed badge and tag variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,17 @@ fmt.Println(ty.FootnoteSection([]string{
 | `Ins(text)`                   | Inserted text, prefixed with `+`                                                            |
 | `Del(text)`                   | Deleted text, prefixed with `-`, strikethrough                                              |
 | `Badge(text)`                 | Styled pill/tag label (e.g. `[SUCCESS]`, `[BETA]`)                                          |
-| `BadgeWithStyle(text, style)` | Badge with a one-off style override for semantic variants                                   |
+| `BadgeWithStyle(text, style)` | Badge with a one-off style override                                                         |
 | `Tag(text)`                   | Subtle pill/category label (lighter variant of Badge)                                       |
 | `TagWithStyle(text, style)`   | Tag with a one-off style override                                                           |
+| `SuccessBadge(text)`          | Badge using the theme's success color (green)                                               |
+| `WarningBadge(text)`          | Badge using the theme's warning color (amber)                                               |
+| `ErrorBadge(text)`            | Badge using the theme's error color (red)                                                   |
+| `InfoBadge(text)`             | Badge using the theme's info color (blue)                                                   |
+| `SuccessTag(text)`            | Tag using the theme's success color                                                         |
+| `WarningTag(text)`            | Tag using the theme's warning color                                                         |
+| `ErrorTag(text)`              | Tag using the theme's error color                                                           |
+| `InfoTag(text)`               | Tag using the theme's info color                                                            |
 
 ```go
 fmt.Println(ty.Bold("important") + " and " + ty.Italic("nuanced"))
@@ -211,6 +219,10 @@ fmt.Println(ty.Ins("added line"))
 fmt.Println(ty.Del("removed line"))
 fmt.Println(ty.Badge("SUCCESS") + " " + ty.Badge("BETA"))
 fmt.Println(ty.Tag("v2.0") + " " + ty.Tag("go"))
+
+// Semantic variants use the theme's status colors automatically
+fmt.Println(ty.SuccessBadge("running"), ty.ErrorBadge("failed"), ty.WarningBadge("expiring"), ty.InfoBadge("pending"))
+fmt.Println(ty.SuccessTag("healthy"), ty.ErrorTag("critical"), ty.WarningTag("degraded"), ty.InfoTag("maintenance"))
 ```
 
 ```text
@@ -468,12 +480,17 @@ ty := herald.New()
 fmt.Println(ty.Ins("Build completed successfully"))  // green, prefixed with +
 fmt.Println(ty.Del("3 tests failed"))                // red, prefixed with -
 
-// Status badges inline with text
-fmt.Println(ty.Badge("PASS") + " " + "All checks passed")
-fmt.Println(ty.Badge("FAIL") + " " + "Linter found 2 issues")
+// Semantic badges use the theme's status colors automatically
+fmt.Println(ty.SuccessBadge("PASS") + " " + "All checks passed")
+fmt.Println(ty.ErrorBadge("FAIL") + " " + "Linter found 2 issues")
+fmt.Println(ty.WarningBadge("EXPIRING") + " " + "Certificate expires in 7 days")
+fmt.Println(ty.InfoBadge("PENDING") + " " + "Deployment queued")
 
-// Subtle labels for categories
-fmt.Println(ty.Tag("v2.1.0") + " " + ty.Tag("stable"))
+// Semantic tags for subtle status labels
+fmt.Println(ty.SuccessTag("healthy") + " " + ty.Tag("v2.1.0"))
+
+// Generic Badge/BadgeWithStyle for non-semantic cases
+fmt.Println(ty.Badge("BETA") + " " + ty.Tag("go"))
 ```
 
 ### Annotated sections
@@ -614,10 +631,19 @@ ty := herald.New(
 
 #### Badge & Tag
 
-| Option           | Targets |
-| ---------------- | ------- |
-| `WithBadgeStyle` | `Badge` |
-| `WithTagStyle`   | `Tag`   |
+| Option                    | Targets                |
+| ------------------------- | ---------------------- |
+| `WithBadgeStyle`          | `Badge`                |
+| `WithTagStyle`            | `Tag`                  |
+| `WithSemanticPalette(sp)` | All 8 semantic methods |
+| `WithSuccessBadgeStyle`   | `SuccessBadge`         |
+| `WithWarningBadgeStyle`   | `WarningBadge`         |
+| `WithErrorBadgeStyle`     | `ErrorBadge`           |
+| `WithInfoBadgeStyle`      | `InfoBadge`            |
+| `WithSuccessTagStyle`     | `SuccessTag`           |
+| `WithWarningTagStyle`     | `WarningTag`           |
+| `WithErrorTagStyle`       | `ErrorTag`             |
+| `WithInfoTagStyle`        | `InfoTag`              |
 
 #### Footnotes
 
@@ -847,9 +873,39 @@ Each `lightDark(lightColor, darkColor)` call returns a single adaptive color tha
 
 Plain `lipgloss.Color` values (without `LightDark`) work too - they apply the same color regardless of terminal background.
 
+#### Semantic palette
+
+`SemanticPalette` defines four status colors used to derive the themed `SuccessBadge`, `WarningBadge`, `ErrorBadge`, `InfoBadge`, `SuccessTag`, `WarningTag`, `ErrorTag`, and `InfoTag` styles.
+
+| Field     | Semantic meaning              | Default derivation from `ColorPalette` |
+| --------- | ----------------------------- | -------------------------------------- |
+| `Success` | Running, passed, healthy      | `Tertiary` (green in most themes)      |
+| `Warning` | Expiring, degraded            | `Accent` (amber in most themes)        |
+| `Error`   | Failed, critical, down        | `Highlight` (red in most themes)       |
+| `Info`    | Informational, neutral status | `Secondary` (blue in most themes)      |
+
+`ThemeFromPalette` automatically derives a `SemanticPalette` from your `ColorPalette`, so existing custom palettes produce valid semantic badge and tag styles without any changes.
+
+Use `WithSemanticPalette` to override all four semantic colors at once:
+
+```go
+ty := herald.New(
+    herald.WithSemanticPalette(herald.SemanticPalette{
+        Success: lipgloss.Color("#22c55e"),
+        Warning: lipgloss.Color("#f59e0b"),
+        Error:   lipgloss.Color("#ef4444"),
+        Info:    lipgloss.Color("#3b82f6"),
+    }),
+)
+```
+
+Individual styles can be overridden with `WithSuccessBadgeStyle`, `WithErrorTagStyle`, and the other per-variant options listed in [Badge & Tag](#badge--tag).
+
 #### Alert palette
 
-`AlertPalette` lets you override the 5 alert colors independently from the main `ColorPalette`. Use `lipgloss.LightDark` for adaptive colors, or plain `lipgloss.Color` for a fixed palette:
+`AlertPalette` lets you override the 5 alert colors independently from the main `ColorPalette`. By default, alert colors are derived from the semantic palette (`DefaultAlertPalette` maps `Info->Note`, `Success->Tip`, `Warning->Warning`, `Error->Caution`), with `Important` using `ColorPalette.Secondary`. Changing the semantic palette therefore updates alert colors too.
+
+Use `WithAlertPalette` to override all 5 alert colors independently:
 
 ```go
 ty := herald.New(
@@ -996,6 +1052,7 @@ Runnable examples are in the [`examples/`](examples/) directory:
 | [001_lists](examples/001_lists/)                                                       | Flat, nested, mixed, and hierarchical lists                                       |
 | [002_alerts](examples/002_alerts/)                                                     | GitHub-style alert callouts (Note, Tip, Important, Warning, Caution)              |
 | [003_table](examples/003_table/)                                                       | Table rendering: bordered, minimal, alignment, striped rows, captions, and footer |
+| [004_semantic-badges](examples/004_semantic-badges/)                                   | Semantic badge and tag methods with default and custom `SemanticPalette`          |
 | [100_custom-options](examples/100_custom-options/)                                     | Override styles, decoration chars, and tokens via functional options              |
 | [101_custom-palette](examples/101_custom-palette/)                                     | Custom adaptive theme from 9 colors using `ColorPalette` and `LightDark`          |
 | [102_builtin-themes](examples/102_builtin-themes/)                                     | Built-in themes (Dracula, Catppuccin, Base16, Charm) matching huh                 |

--- a/alert_palette.go
+++ b/alert_palette.go
@@ -17,6 +17,20 @@ type AlertPalette struct {
 	Caution   color.Color // red
 }
 
+// DefaultAlertPalette derives an AlertPalette from a SemanticPalette and
+// a ColorPalette. The four shared semantics map directly (Info->Note,
+// Success->Tip, Warning->Warning, Error->Caution); Important uses
+// ColorPalette.Secondary (purple) which has no semantic equivalent.
+func DefaultAlertPalette(sp SemanticPalette, p ColorPalette) AlertPalette {
+	return AlertPalette{
+		Note:      sp.Info,    // blue
+		Tip:       sp.Success, // green
+		Important: p.Secondary,
+		Warning:   sp.Warning, // yellow/amber
+		Caution:   sp.Error,   // red
+	}
+}
+
 // DefaultAlertConfigs builds a full map[AlertType]AlertConfig from an
 // AlertPalette, using default icons and labels and creating a lipgloss.Style
 // with the palette color as foreground.

--- a/examples/004_semantic-badges/main.go
+++ b/examples/004_semantic-badges/main.go
@@ -1,0 +1,49 @@
+// Semantic badges and tags demo with the default Rose Pine theme.
+// Run: go run ./examples/004_semantic-badges/
+package main
+
+import (
+	"fmt"
+
+	"charm.land/lipgloss/v2"
+	"github.com/indaco/herald"
+)
+
+func main() {
+	ty := herald.New()
+
+	fmt.Println(ty.H2("Semantic Badges"))
+	fmt.Println(
+		ty.SuccessBadge("running"),
+		ty.ErrorBadge("failed"),
+		ty.WarningBadge("expiring"),
+		ty.InfoBadge("pending"),
+	)
+	fmt.Println()
+
+	fmt.Println(ty.H2("Semantic Tags"))
+	fmt.Println(
+		ty.SuccessTag("healthy"),
+		ty.ErrorTag("critical"),
+		ty.WarningTag("degraded"),
+		ty.InfoTag("maintenance"),
+	)
+	fmt.Println()
+
+	// Custom semantic palette
+	fmt.Println(ty.H2("Custom Semantic Palette"))
+	custom := herald.New(
+		herald.WithSemanticPalette(herald.SemanticPalette{
+			Success: lipgloss.Color("#22c55e"),
+			Warning: lipgloss.Color("#f59e0b"),
+			Error:   lipgloss.Color("#ef4444"),
+			Info:    lipgloss.Color("#3b82f6"),
+		}),
+	)
+	fmt.Println(
+		custom.SuccessBadge("passed"),
+		custom.ErrorBadge("error"),
+		custom.WarningBadge("warning"),
+		custom.InfoBadge("info"),
+	)
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,12 +18,13 @@ Some examples live in the root module and can be run directly with `go run`. Oth
 
 ### Core elements (`0xx`)
 
-| Example                                 | Description                                                                       | Run                                    |
-| --------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------- |
-| [000_default-theme](000_default-theme/) | All elements with the default Rose Pine theme                                     | `go run ./examples/000_default-theme/` |
-| [001_lists](001_lists/)                 | Flat, nested, mixed, and hierarchical lists                                       | `go run ./examples/001_lists/`         |
-| [002_alerts](002_alerts/)               | GitHub-style alert callouts (Note, Tip, Important, Warning, Caution)              | `go run ./examples/002_alerts/`        |
-| [003_table](003_table/)                 | Table rendering: bordered, minimal, alignment, striped rows, captions, and footer | `go run ./examples/003_table/`         |
+| Example                                     | Description                                                                       | Run                                      |
+| ------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------- |
+| [000_default-theme](000_default-theme/)     | All elements with the default Rose Pine theme                                     | `go run ./examples/000_default-theme/`   |
+| [001_lists](001_lists/)                     | Flat, nested, mixed, and hierarchical lists                                       | `go run ./examples/001_lists/`           |
+| [002_alerts](002_alerts/)                   | GitHub-style alert callouts (Note, Tip, Important, Warning, Caution)              | `go run ./examples/002_alerts/`          |
+| [003_table](003_table/)                     | Table rendering: bordered, minimal, alignment, striped rows, captions, and footer | `go run ./examples/003_table/`           |
+| [004_semantic-badges](004_semantic-badges/) | Semantic badges and tags with default and custom palettes                         | `go run ./examples/004_semantic-badges/` |
 
 ### Customization (`1xx`)
 

--- a/examples/demos/hero/main.go
+++ b/examples/demos/hero/main.go
@@ -56,6 +56,7 @@ func main() {
 			ty.Code("inline code"),
 	)
 	fmt.Println(ty.Ins("added") + "  " + ty.Del("removed") + "  " + ty.Badge("NEW") + "  " + ty.Tag("go"))
+	fmt.Println(ty.SuccessBadge("running") + "  " + ty.ErrorBadge("failed") + "  " + ty.WarningBadge("expiring") + "  " + ty.InfoBadge("pending"))
 	fmt.Println()
 
 	// Key-value

--- a/examples/demos/inline/main.go
+++ b/examples/demos/inline/main.go
@@ -23,6 +23,8 @@ func main() {
 	fmt.Println(ty.Ins("added line"))
 	fmt.Println(ty.Del("removed line"))
 	fmt.Println(ty.Badge("SUCCESS") + " " + ty.Badge("BETA") + " " + ty.Tag("v2.0") + " " + ty.Tag("go"))
+	fmt.Println(ty.SuccessBadge("running") + " " + ty.WarningBadge("expiring") + " " + ty.ErrorBadge("failed") + " " + ty.InfoBadge("pending"))
+	fmt.Println(ty.SuccessTag("healthy") + " " + ty.WarningTag("degraded") + " " + ty.ErrorTag("critical") + " " + ty.InfoTag("maintenance"))
 	fmt.Println()
 
 	fmt.Println(ty.Link("https://go.dev"))

--- a/options.go
+++ b/options.go
@@ -216,6 +216,60 @@ func WithTagStyle(s lipgloss.Style) Option {
 	return func(ty *Typography) { ty.theme.Tag = s }
 }
 
+// --- Semantic badge/tag style options ---
+
+// WithSemanticPalette rebuilds the 8 semantic badge/tag styles from the
+// provided SemanticPalette, using the current theme's Badge foreground (Base)
+// and Tag background (Surface) colors. Same pattern as WithAlertPalette.
+func WithSemanticPalette(sp SemanticPalette) Option {
+	return func(ty *Typography) {
+		base := ty.theme.Badge.GetForeground()
+		surface := ty.theme.Tag.GetBackground()
+		ty.theme.SuccessBadge, ty.theme.WarningBadge, ty.theme.ErrorBadge, ty.theme.InfoBadge = defaultSemanticBadgeStyles(sp, base)
+		ty.theme.SuccessTag, ty.theme.WarningTag, ty.theme.ErrorTag, ty.theme.InfoTag = defaultSemanticTagStyles(sp, surface)
+	}
+}
+
+// WithSuccessBadgeStyle overrides the success badge style.
+func WithSuccessBadgeStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.SuccessBadge = s }
+}
+
+// WithWarningBadgeStyle overrides the warning badge style.
+func WithWarningBadgeStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.WarningBadge = s }
+}
+
+// WithErrorBadgeStyle overrides the error badge style.
+func WithErrorBadgeStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.ErrorBadge = s }
+}
+
+// WithInfoBadgeStyle overrides the info badge style.
+func WithInfoBadgeStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.InfoBadge = s }
+}
+
+// WithSuccessTagStyle overrides the success tag style.
+func WithSuccessTagStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.SuccessTag = s }
+}
+
+// WithWarningTagStyle overrides the warning tag style.
+func WithWarningTagStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.WarningTag = s }
+}
+
+// WithErrorTagStyle overrides the error tag style.
+func WithErrorTagStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.ErrorTag = s }
+}
+
+// WithInfoTagStyle overrides the info tag style.
+func WithInfoTagStyle(s lipgloss.Style) Option {
+	return func(ty *Typography) { ty.theme.InfoTag = s }
+}
+
 // --- Footnote style options ---
 
 // WithFootnoteRefStyle overrides the inline footnote reference marker style.

--- a/options_test.go
+++ b/options_test.go
@@ -477,6 +477,93 @@ func TestWithCodeLineNumberSep(t *testing.T) {
 	}
 }
 
+func TestWithSemanticBadgeTagStyles(t *testing.T) {
+	style := lipgloss.NewStyle().Bold(true)
+
+	tests := []struct {
+		name string
+		opt  Option
+		get  func(*Typography) lipgloss.Style
+	}{
+		{"SuccessBadge", WithSuccessBadgeStyle(style), func(ty *Typography) lipgloss.Style { return ty.theme.SuccessBadge }},
+		{"WarningBadge", WithWarningBadgeStyle(style), func(ty *Typography) lipgloss.Style { return ty.theme.WarningBadge }},
+		{"ErrorBadge", WithErrorBadgeStyle(style), func(ty *Typography) lipgloss.Style { return ty.theme.ErrorBadge }},
+		{"InfoBadge", WithInfoBadgeStyle(style), func(ty *Typography) lipgloss.Style { return ty.theme.InfoBadge }},
+		{"SuccessTag", WithSuccessTagStyle(style), func(ty *Typography) lipgloss.Style { return ty.theme.SuccessTag }},
+		{"WarningTag", WithWarningTagStyle(style), func(ty *Typography) lipgloss.Style { return ty.theme.WarningTag }},
+		{"ErrorTag", WithErrorTagStyle(style), func(ty *Typography) lipgloss.Style { return ty.theme.ErrorTag }},
+		{"InfoTag", WithInfoTagStyle(style), func(ty *Typography) lipgloss.Style { return ty.theme.InfoTag }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ty := New(tc.opt)
+			got := tc.get(ty)
+			result := got.Render("test")
+			if result == "" {
+				t.Error("expected non-empty render")
+			}
+		})
+	}
+}
+
+func TestWithSemanticPalette(t *testing.T) {
+	sp := SemanticPalette{
+		Success: lipgloss.Color("#00FF00"),
+		Warning: lipgloss.Color("#FFFF00"),
+		Error:   lipgloss.Color("#FF0000"),
+		Info:    lipgloss.Color("#0000FF"),
+	}
+
+	ty := New(WithSemanticPalette(sp))
+
+	// All 8 styles should render non-empty output
+	tests := []struct {
+		name   string
+		render func(string) string
+	}{
+		{"SuccessBadge", ty.SuccessBadge},
+		{"WarningBadge", ty.WarningBadge},
+		{"ErrorBadge", ty.ErrorBadge},
+		{"InfoBadge", ty.InfoBadge},
+		{"SuccessTag", ty.SuccessTag},
+		{"WarningTag", ty.WarningTag},
+		{"ErrorTag", ty.ErrorTag},
+		{"InfoTag", ty.InfoTag},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := stripANSI(tc.render("test"))
+			if !strings.Contains(result, "test") {
+				t.Errorf("%s: expected 'test' in output, got %q", tc.name, result)
+			}
+		})
+	}
+}
+
+func TestWithSemanticPalettePreservesOtherStyles(t *testing.T) {
+	sp := SemanticPalette{
+		Success: lipgloss.Color("#00FF00"),
+		Warning: lipgloss.Color("#FFFF00"),
+		Error:   lipgloss.Color("#FF0000"),
+		Info:    lipgloss.Color("#0000FF"),
+	}
+
+	ty := New(WithSemanticPalette(sp))
+
+	// Badge and Tag (non-semantic) should still work
+	result := stripANSI(ty.Badge("BETA"))
+	if !strings.Contains(result, "BETA") {
+		t.Errorf("Badge should still work after WithSemanticPalette, got %q", result)
+	}
+
+	result = stripANSI(ty.Tag("v1.0"))
+	if !strings.Contains(result, "v1.0") {
+		t.Errorf("Tag should still work after WithSemanticPalette, got %q", result)
+	}
+}
+
 func TestMultipleOptions(t *testing.T) {
 	ty := New(
 		WithHRWidth(80),

--- a/palette.go
+++ b/palette.go
@@ -24,6 +24,10 @@ type ColorPalette struct {
 // ThemeFromPalette constructs a complete Theme by mapping palette colors to
 // all style fields. Configurable tokens use the same defaults as DefaultTheme.
 func ThemeFromPalette(p ColorPalette) Theme {
+	sp := DefaultSemanticPalette(p)
+	sbSuccess, sbWarning, sbError, sbInfo := defaultSemanticBadgeStyles(sp, p.Base)
+	stSuccess, stWarning, stError, stInfo := defaultSemanticTagStyles(sp, p.Surface)
+
 	return Theme{
 		H1: lipgloss.NewStyle().
 			Bold(true).
@@ -170,6 +174,16 @@ func ThemeFromPalette(p ColorPalette) Theme {
 			Background(p.Surface).
 			Padding(0, 1),
 
+		SuccessBadge: sbSuccess,
+		WarningBadge: sbWarning,
+		ErrorBadge:   sbError,
+		InfoBadge:    sbInfo,
+
+		SuccessTag: stSuccess,
+		WarningTag: stWarning,
+		ErrorTag:   stError,
+		InfoTag:    stInfo,
+
 		FootnoteRef:     lipgloss.NewStyle().Foreground(p.Tertiary),
 		FootnoteItem:    lipgloss.NewStyle().Foreground(p.Muted),
 		FootnoteDivider: lipgloss.NewStyle().Foreground(p.Muted),
@@ -207,12 +221,6 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		TableCellPad:   DefaultTableCellPad,
 
 		AlertBar: DefaultAlertBar,
-		Alerts: DefaultAlertConfigs(AlertPalette{
-			Note:      p.Tertiary,  // blue/cyan
-			Tip:       p.Tertiary,  // green in some palettes
-			Important: p.Secondary, // purple
-			Warning:   p.Accent,    // yellow/amber
-			Caution:   p.Highlight, // red
-		}),
+		Alerts:   DefaultAlertConfigs(DefaultAlertPalette(sp, p)),
 	}
 }

--- a/semantic_palette.go
+++ b/semantic_palette.go
@@ -1,0 +1,61 @@
+package herald
+
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
+
+// SemanticPalette defines four colors for common status semantics. It is
+// separate from ColorPalette (which maps to typographic elements) and from
+// AlertPalette (which maps to GitHub-style alert callouts). A SemanticPalette
+// is used to derive themed badge and tag styles for status indicators.
+type SemanticPalette struct {
+	Success color.Color // green  - running, passed, healthy
+	Warning color.Color // yellow/amber - expiring, degraded
+	Error   color.Color // red - failed, critical, down
+	Info    color.Color // blue - informational, neutral status
+}
+
+// DefaultSemanticPalette derives a SemanticPalette from the given ColorPalette
+// using sensible defaults:
+//
+//   - Success -> Tertiary  (green in most themes)
+//   - Warning -> Accent    (yellow/amber in most themes)
+//   - Error   -> Highlight (red in most themes)
+//   - Info    -> Secondary (blue/purple in most themes)
+func DefaultSemanticPalette(p ColorPalette) SemanticPalette {
+	return SemanticPalette{
+		Success: p.Tertiary,
+		Warning: p.Accent,
+		Error:   p.Highlight,
+		Info:    p.Secondary,
+	}
+}
+
+// defaultSemanticBadgeStyles builds the four semantic badge styles from a
+// SemanticPalette. Badge styles use a bold pill with the semantic color as
+// background and the given base color as foreground.
+func defaultSemanticBadgeStyles(sp SemanticPalette, base color.Color) (success, warning, errStyle, info lipgloss.Style) {
+	badge := func(bg color.Color) lipgloss.Style {
+		return lipgloss.NewStyle().
+			Background(bg).
+			Foreground(base).
+			Bold(true).
+			Padding(0, 1)
+	}
+	return badge(sp.Success), badge(sp.Warning), badge(sp.Error), badge(sp.Info)
+}
+
+// defaultSemanticTagStyles builds the four semantic tag styles from a
+// SemanticPalette. Tag styles use the semantic color as foreground and the
+// given surface color as background.
+func defaultSemanticTagStyles(sp SemanticPalette, surface color.Color) (success, warning, errStyle, info lipgloss.Style) {
+	tag := func(fg color.Color) lipgloss.Style {
+		return lipgloss.NewStyle().
+			Foreground(fg).
+			Background(surface).
+			Padding(0, 1)
+	}
+	return tag(sp.Success), tag(sp.Warning), tag(sp.Error), tag(sp.Info)
+}

--- a/semantic_palette_test.go
+++ b/semantic_palette_test.go
@@ -1,0 +1,178 @@
+package herald
+
+import (
+	"image/color"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+func TestDefaultSemanticPalette(t *testing.T) {
+	p := ColorPalette{
+		Primary:   color.Black,
+		Secondary: lipgloss.Color("#0000FF"),
+		Tertiary:  lipgloss.Color("#00FF00"),
+		Accent:    lipgloss.Color("#FFFF00"),
+		Highlight: lipgloss.Color("#FF0000"),
+		Muted:     lipgloss.Color("#888888"),
+		Text:      color.Black,
+		Surface:   lipgloss.Color("#333333"),
+		Base:      lipgloss.Color("#FFFFFF"),
+	}
+
+	sp := DefaultSemanticPalette(p)
+
+	// Success should derive from Tertiary
+	if sp.Success != p.Tertiary {
+		t.Errorf("Success: expected Tertiary, got different color")
+	}
+	// Warning should derive from Accent
+	if sp.Warning != p.Accent {
+		t.Errorf("Warning: expected Accent, got different color")
+	}
+	// Error should derive from Highlight
+	if sp.Error != p.Highlight {
+		t.Errorf("Error: expected Highlight, got different color")
+	}
+	// Info should derive from Secondary
+	if sp.Info != p.Secondary {
+		t.Errorf("Info: expected Secondary, got different color")
+	}
+}
+
+func TestSemanticPaletteFromThemeFromPalette(t *testing.T) {
+	p := ColorPalette{
+		Primary:   color.Black,
+		Secondary: lipgloss.Color("#0000FF"),
+		Tertiary:  lipgloss.Color("#00FF00"),
+		Accent:    lipgloss.Color("#FFFF00"),
+		Highlight: lipgloss.Color("#FF0000"),
+		Muted:     lipgloss.Color("#888888"),
+		Text:      color.Black,
+		Surface:   lipgloss.Color("#333333"),
+		Base:      lipgloss.Color("#FFFFFF"),
+	}
+
+	theme := ThemeFromPalette(p)
+
+	// All 8 semantic styles should render non-empty output
+	styles := []struct {
+		name  string
+		style lipgloss.Style
+	}{
+		{"SuccessBadge", theme.SuccessBadge},
+		{"WarningBadge", theme.WarningBadge},
+		{"ErrorBadge", theme.ErrorBadge},
+		{"InfoBadge", theme.InfoBadge},
+		{"SuccessTag", theme.SuccessTag},
+		{"WarningTag", theme.WarningTag},
+		{"ErrorTag", theme.ErrorTag},
+		{"InfoTag", theme.InfoTag},
+	}
+
+	for _, tc := range styles {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.style.Render("test")
+			if result == "" {
+				t.Errorf("%s rendered empty string", tc.name)
+			}
+		})
+	}
+}
+
+func TestSemanticBadgeStylesHaveBoldAndPadding(t *testing.T) {
+	sp := SemanticPalette{
+		Success: lipgloss.Color("#00FF00"),
+		Warning: lipgloss.Color("#FFFF00"),
+		Error:   lipgloss.Color("#FF0000"),
+		Info:    lipgloss.Color("#0000FF"),
+	}
+	base := lipgloss.Color("#FFFFFF")
+
+	success, warning, errStyle, info := defaultSemanticBadgeStyles(sp, base)
+
+	for _, tc := range []struct {
+		name  string
+		style lipgloss.Style
+	}{
+		{"Success", success},
+		{"Warning", warning},
+		{"Error", errStyle},
+		{"Info", info},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !tc.style.GetBold() {
+				t.Errorf("%s badge should be bold", tc.name)
+			}
+			top, right, bottom, left := tc.style.GetPadding()
+			if top != 0 || bottom != 0 || left != 1 || right != 1 {
+				t.Errorf("%s badge padding: got (%d,%d,%d,%d), want (0,1,0,1)", tc.name, top, right, bottom, left)
+			}
+		})
+	}
+}
+
+func TestSemanticTagStylesHavePadding(t *testing.T) {
+	sp := SemanticPalette{
+		Success: lipgloss.Color("#00FF00"),
+		Warning: lipgloss.Color("#FFFF00"),
+		Error:   lipgloss.Color("#FF0000"),
+		Info:    lipgloss.Color("#0000FF"),
+	}
+	surface := lipgloss.Color("#333333")
+
+	success, warning, errStyle, info := defaultSemanticTagStyles(sp, surface)
+
+	for _, tc := range []struct {
+		name  string
+		style lipgloss.Style
+	}{
+		{"Success", success},
+		{"Warning", warning},
+		{"Error", errStyle},
+		{"Info", info},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			top, right, bottom, left := tc.style.GetPadding()
+			if top != 0 || bottom != 0 || left != 1 || right != 1 {
+				t.Errorf("%s tag padding: got (%d,%d,%d,%d), want (0,1,0,1)", tc.name, top, right, bottom, left)
+			}
+		})
+	}
+}
+
+func TestSemanticStylesInAllThemes(t *testing.T) {
+	themes := map[string]func() Theme{
+		"Default":    DefaultTheme,
+		"Dracula":    DraculaTheme,
+		"Catppuccin": CatppuccinTheme,
+		"Base16":     Base16Theme,
+		"Charm":      CharmTheme,
+	}
+
+	for name, themeFn := range themes {
+		t.Run(name, func(t *testing.T) {
+			theme := themeFn()
+			styles := []struct {
+				label string
+				style lipgloss.Style
+			}{
+				{"SuccessBadge", theme.SuccessBadge},
+				{"WarningBadge", theme.WarningBadge},
+				{"ErrorBadge", theme.ErrorBadge},
+				{"InfoBadge", theme.InfoBadge},
+				{"SuccessTag", theme.SuccessTag},
+				{"WarningTag", theme.WarningTag},
+				{"ErrorTag", theme.ErrorTag},
+				{"InfoTag", theme.InfoTag},
+			}
+
+			for _, s := range styles {
+				result := s.style.Render("test")
+				if result == "" {
+					t.Errorf("%s: %s rendered empty", name, s.label)
+				}
+			}
+		})
+	}
+}

--- a/theme.go
+++ b/theme.go
@@ -64,6 +64,17 @@ type Theme struct {
 	Badge lipgloss.Style // style for bold pill/status labels
 	Tag   lipgloss.Style // style for subtle pill/category labels
 
+	// Semantic badge/tag styles (derived from SemanticPalette)
+	SuccessBadge lipgloss.Style
+	WarningBadge lipgloss.Style
+	ErrorBadge   lipgloss.Style
+	InfoBadge    lipgloss.Style
+
+	SuccessTag lipgloss.Style
+	WarningTag lipgloss.Style
+	ErrorTag   lipgloss.Style
+	InfoTag    lipgloss.Style
+
 	// Footnote elements
 	FootnoteRef     lipgloss.Style // style for inline reference markers (e.g. "[1]")
 	FootnoteItem    lipgloss.Style // style for each footnote entry in the section
@@ -258,6 +269,18 @@ func DefaultTheme() Theme {
 		Warning:   lightDark(lipgloss.Color("#D7827E"), lipgloss.Color("#F6C177")), // gold
 		Caution:   lightDark(lipgloss.Color("#B4637A"), lipgloss.Color("#EB6F92")), // love
 	})
+
+	// Semantic palette: Rose Pine foam/gold/love/iris
+	rosePineSP := SemanticPalette{
+		Success: lightDark(lipgloss.Color("#286983"), lipgloss.Color("#9CCFD8")), // foam/pine (green)
+		Warning: lightDark(lipgloss.Color("#D7827E"), lipgloss.Color("#F6C177")), // gold (amber)
+		Error:   lightDark(lipgloss.Color("#B4637A"), lipgloss.Color("#EB6F92")), // love (red)
+		Info:    lightDark(lipgloss.Color("#3e8fb0"), lipgloss.Color("#9CCFD8")), // foam (blue)
+	}
+	base := theme.Badge.GetForeground()
+	surface := theme.Tag.GetBackground()
+	theme.SuccessBadge, theme.WarningBadge, theme.ErrorBadge, theme.InfoBadge = defaultSemanticBadgeStyles(rosePineSP, base)
+	theme.SuccessTag, theme.WarningTag, theme.ErrorTag, theme.InfoTag = defaultSemanticTagStyles(rosePineSP, surface)
 
 	return theme
 }

--- a/themes.go
+++ b/themes.go
@@ -30,6 +30,18 @@ func DraculaTheme() Theme {
 		Caution:   lightDark(lipgloss.Color("#c44040"), lipgloss.Color("#ff5555")), // red
 	})
 
+	// Semantic palette: Dracula green/yellow/red/cyan
+	draculaSP := SemanticPalette{
+		Success: lightDark(lipgloss.Color("#1e9651"), lipgloss.Color("#50fa7b")), // green
+		Warning: lightDark(lipgloss.Color("#b07d2b"), lipgloss.Color("#f1fa8c")), // yellow
+		Error:   lightDark(lipgloss.Color("#c44040"), lipgloss.Color("#ff5555")), // red
+		Info:    lightDark(lipgloss.Color("#1e6e99"), lipgloss.Color("#8be9fd")), // cyan
+	}
+	base := theme.Badge.GetForeground()
+	surface := theme.Tag.GetBackground()
+	theme.SuccessBadge, theme.WarningBadge, theme.ErrorBadge, theme.InfoBadge = defaultSemanticBadgeStyles(draculaSP, base)
+	theme.SuccessTag, theme.WarningTag, theme.ErrorTag, theme.InfoTag = defaultSemanticTagStyles(draculaSP, surface)
+
 	return theme
 }
 
@@ -58,6 +70,18 @@ func CatppuccinTheme() Theme {
 		Warning:   lightDark(lipgloss.Color("#fe640b"), lipgloss.Color("#fab387")), // peach
 		Caution:   lightDark(lipgloss.Color("#d20f39"), lipgloss.Color("#f38ba8")), // red
 	})
+
+	// Semantic palette: Catppuccin green/peach/red/blue
+	catppuccinSP := SemanticPalette{
+		Success: lightDark(lipgloss.Color("#40a02b"), lipgloss.Color("#a6e3a1")), // green
+		Warning: lightDark(lipgloss.Color("#fe640b"), lipgloss.Color("#fab387")), // peach
+		Error:   lightDark(lipgloss.Color("#d20f39"), lipgloss.Color("#f38ba8")), // red
+		Info:    lightDark(lipgloss.Color("#1e66f5"), lipgloss.Color("#89b4fa")), // blue
+	}
+	base := theme.Badge.GetForeground()
+	surface := theme.Tag.GetBackground()
+	theme.SuccessBadge, theme.WarningBadge, theme.ErrorBadge, theme.InfoBadge = defaultSemanticBadgeStyles(catppuccinSP, base)
+	theme.SuccessTag, theme.WarningTag, theme.ErrorTag, theme.InfoTag = defaultSemanticTagStyles(catppuccinSP, surface)
 
 	return theme
 }
@@ -88,6 +112,18 @@ func Base16Theme() Theme {
 		Caution:   lightDark(lipgloss.Color("1"), lipgloss.Color("1")), // red
 	})
 
+	// Semantic palette: ANSI green/yellow/red/blue
+	base16SP := SemanticPalette{
+		Success: lightDark(lipgloss.Color("2"), lipgloss.Color("2")), // green
+		Warning: lightDark(lipgloss.Color("3"), lipgloss.Color("3")), // yellow
+		Error:   lightDark(lipgloss.Color("1"), lipgloss.Color("1")), // red
+		Info:    lightDark(lipgloss.Color("4"), lipgloss.Color("4")), // blue
+	}
+	base := theme.Badge.GetForeground()
+	surface := theme.Tag.GetBackground()
+	theme.SuccessBadge, theme.WarningBadge, theme.ErrorBadge, theme.InfoBadge = defaultSemanticBadgeStyles(base16SP, base)
+	theme.SuccessTag, theme.WarningTag, theme.ErrorTag, theme.InfoTag = defaultSemanticTagStyles(base16SP, surface)
+
 	return theme
 }
 
@@ -116,6 +152,18 @@ func CharmTheme() Theme {
 		Warning:   lightDark(lipgloss.Color("#C740B0"), lipgloss.Color("#F780E2")), // charm pink/warm
 		Caution:   lightDark(lipgloss.Color("#C7304E"), lipgloss.Color("#ED567A")), // charm red
 	})
+
+	// Semantic palette: Charm green/pink/red/blue
+	charmSP := SemanticPalette{
+		Success: lightDark(lipgloss.Color("#02BA84"), lipgloss.Color("#02BF87")), // charm green
+		Warning: lightDark(lipgloss.Color("#C740B0"), lipgloss.Color("#F780E2")), // charm pink/warm
+		Error:   lightDark(lipgloss.Color("#C7304E"), lipgloss.Color("#ED567A")), // charm red
+		Info:    lightDark(lipgloss.Color("#2563EB"), lipgloss.Color("#60A5FA")), // charm blue
+	}
+	base := theme.Badge.GetForeground()
+	surface := theme.Tag.GetBackground()
+	theme.SuccessBadge, theme.WarningBadge, theme.ErrorBadge, theme.InfoBadge = defaultSemanticBadgeStyles(charmSP, base)
+	theme.SuccessTag, theme.WarningTag, theme.ErrorTag, theme.InfoTag = defaultSemanticTagStyles(charmSP, surface)
 
 	return theme
 }

--- a/typography.go
+++ b/typography.go
@@ -895,6 +895,54 @@ func (t *Typography) TagWithStyle(text string, style lipgloss.Style) string {
 }
 
 // ---------------------------------------------------------------------------
+// Semantic Badges
+// ---------------------------------------------------------------------------
+
+// SuccessBadge renders a badge styled for success/positive status.
+func (t *Typography) SuccessBadge(text string) string {
+	return t.theme.SuccessBadge.Render(text)
+}
+
+// WarningBadge renders a badge styled for warning/degraded status.
+func (t *Typography) WarningBadge(text string) string {
+	return t.theme.WarningBadge.Render(text)
+}
+
+// ErrorBadge renders a badge styled for error/critical status.
+func (t *Typography) ErrorBadge(text string) string {
+	return t.theme.ErrorBadge.Render(text)
+}
+
+// InfoBadge renders a badge styled for informational status.
+func (t *Typography) InfoBadge(text string) string {
+	return t.theme.InfoBadge.Render(text)
+}
+
+// ---------------------------------------------------------------------------
+// Semantic Tags
+// ---------------------------------------------------------------------------
+
+// SuccessTag renders a tag styled for success/positive status.
+func (t *Typography) SuccessTag(text string) string {
+	return t.theme.SuccessTag.Render(text)
+}
+
+// WarningTag renders a tag styled for warning/degraded status.
+func (t *Typography) WarningTag(text string) string {
+	return t.theme.WarningTag.Render(text)
+}
+
+// ErrorTag renders a tag styled for error/critical status.
+func (t *Typography) ErrorTag(text string) string {
+	return t.theme.ErrorTag.Render(text)
+}
+
+// InfoTag renders a tag styled for informational status.
+func (t *Typography) InfoTag(text string) string {
+	return t.theme.InfoTag.Render(text)
+}
+
+// ---------------------------------------------------------------------------
 // Footnote
 // ---------------------------------------------------------------------------
 

--- a/typography_test.go
+++ b/typography_test.go
@@ -1047,6 +1047,66 @@ func TestTagWithStyle(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Semantic Badges
+// ---------------------------------------------------------------------------
+
+func TestSemanticBadges(t *testing.T) {
+	ty := newTestTypography()
+
+	tests := []struct {
+		name string
+		fn   func(string) string
+		text string
+	}{
+		{"SuccessBadge", ty.SuccessBadge, "running"},
+		{"WarningBadge", ty.WarningBadge, "expiring"},
+		{"ErrorBadge", ty.ErrorBadge, "failed"},
+		{"InfoBadge", ty.InfoBadge, "pending"},
+		{"SuccessBadge empty", ty.SuccessBadge, ""},
+		{"ErrorBadge special", ty.ErrorBadge, "<error>"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.fn(tc.text)
+			if tc.text != "" && !strings.Contains(stripANSI(result), tc.text) {
+				t.Errorf("%s(%q) missing text in output %q", tc.name, tc.text, stripANSI(result))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Semantic Tags
+// ---------------------------------------------------------------------------
+
+func TestSemanticTags(t *testing.T) {
+	ty := newTestTypography()
+
+	tests := []struct {
+		name string
+		fn   func(string) string
+		text string
+	}{
+		{"SuccessTag", ty.SuccessTag, "healthy"},
+		{"WarningTag", ty.WarningTag, "degraded"},
+		{"ErrorTag", ty.ErrorTag, "critical"},
+		{"InfoTag", ty.InfoTag, "maintenance"},
+		{"SuccessTag empty", ty.SuccessTag, ""},
+		{"InfoTag unicode", ty.InfoTag, "Bonjour"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.fn(tc.text)
+			if tc.text != "" && !strings.Contains(stripANSI(result), tc.text) {
+				t.Errorf("%s(%q) missing text in output %q", tc.name, tc.text, stripANSI(result))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
 
@@ -1102,10 +1162,10 @@ func TestKV(t *testing.T) {
 	})
 
 	t.Run("custom separator", func(t *testing.T) {
-		ty2 := New(WithKVSeparator(" →"))
+		ty2 := New(WithKVSeparator(" ->"))
 		got := stripANSI(ty2.KV("Name", "Alice"))
-		if got != "Name → Alice" {
-			t.Errorf("KV custom sep = %q, want %q", got, "Name → Alice")
+		if got != "Name -> Alice" {
+			t.Errorf("KV custom sep = %q, want %q", got, "Name -> Alice")
 		}
 	})
 
@@ -1220,6 +1280,14 @@ func TestConcurrentAccess(t *testing.T) {
 			ty.FootnoteSection([]string{"note one", "note two"})
 			ty.KV("key", "value")
 			ty.KVGroup([][2]string{{"a", "1"}, {"bb", "2"}})
+			ty.SuccessBadge("ok")
+			ty.WarningBadge("warn")
+			ty.ErrorBadge("err")
+			ty.InfoBadge("info")
+			ty.SuccessTag("ok")
+			ty.WarningTag("warn")
+			ty.ErrorTag("err")
+			ty.InfoTag("info")
 		}()
 	}
 


### PR DESCRIPTION
## Summary

- Add `SemanticPalette` (Success, Warning, Error, Info) with auto-derivation from `ColorPalette`
- Add themed convenience methods: `SuccessBadge`, `WarningBadge`, `ErrorBadge`, `InfoBadge`, `SuccessTag`, `WarningTag`,  `ErrorTag`, and `InfoTag`
- Add `WithSemanticPalette` option plus individual style override options
- Add `examples/004_semantic-badges` demo