### PR TITLE
feat: support custom start line number in code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,13 +715,14 @@ ty := herald.New(
 
 #### Block tokens
 
-| Option                     | Default | Description                             |
-| -------------------------- | ------- | --------------------------------------- |
-| `WithHRChar(c)`            | `─`     | Character repeated for `HR`             |
-| `WithHRWidth(w)`           | `40`    | Width of `HR` in characters             |
-| `WithBlockquoteBar(c)`     | `│`     | Left bar character for `Blockquote`     |
-| `WithCodeLineNumbers(b)`   | `false` | Show line numbers in `CodeBlock`        |
-| `WithCodeLineNumberSep(c)` | `│`     | Separator between line numbers and code |
+| Option                        | Default | Description                             |
+| ----------------------------- | ------- | --------------------------------------- |
+| `WithHRChar(c)`               | `─`     | Character repeated for `HR`             |
+| `WithHRWidth(w)`              | `40`    | Width of `HR` in characters             |
+| `WithBlockquoteBar(c)`        | `│`     | Left bar character for `Blockquote`     |
+| `WithCodeLineNumbers(b)`      | `false` | Show line numbers in `CodeBlock`        |
+| `WithCodeLineNumberSep(c)`    | `│`     | Separator between line numbers and code |
+| `WithCodeLineNumberOffset(n)` | `1`     | Starting line number for code blocks    |
 
 #### Inline tokens
 
@@ -806,6 +807,23 @@ fmt.Println(ty.CodeBlock("func main() {\n\tfmt.Println(\"hello\")\n}", "go"))
 1│ func main() {
 2│     fmt.Println("hello")
 3│ }
+```
+
+When displaying a snippet from a larger file, set a custom starting line number with `WithCodeLineNumberOffset`:
+
+```go
+ty := herald.New(
+    herald.WithCodeLineNumbers(true),
+    herald.WithCodeLineNumberOffset(42),
+)
+
+fmt.Println(ty.CodeBlock("func greet(name string) string {\n\treturn \"Hello, \" + name\n}"))
+```
+
+```text
+42│ func greet(name string) string {
+43│     return "Hello, " + name
+44│ }
 ```
 
 Customize the separator and style:

--- a/examples/demos/blocks/main.go
+++ b/examples/demos/blocks/main.go
@@ -20,6 +20,10 @@ func main() {
 	// Code block with line numbers
 	tyLN := herald.New(herald.WithCodeLineNumbers(true))
 	fmt.Println(tyLN.CodeBlock("package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}"))
+
+	// Code block with line number offset (e.g. snippet starting at line 42)
+	tyOffset := herald.New(herald.WithCodeLineNumbers(true), herald.WithCodeLineNumberOffset(42))
+	fmt.Println(tyOffset.CodeBlock("func greet(name string) string {\n\treturn \"Hello, \" + name\n}"))
 	fmt.Println()
 
 	fmt.Println(ty.HR())

--- a/options.go
+++ b/options.go
@@ -504,6 +504,17 @@ func WithCodeLineNumberSep(sep string) Option {
 	return func(ty *Typography) { ty.theme.CodeLineNumberSep = sep }
 }
 
+// WithCodeLineNumberOffset sets the starting line number for code blocks.
+// The offset only applies when ShowLineNumbers is true.
+// Values less than 1 are ignored; the default is 1.
+func WithCodeLineNumberOffset(n int) Option {
+	return func(ty *Typography) {
+		if n >= 1 {
+			ty.theme.CodeLineNumberOffset = n
+		}
+	}
+}
+
 // --- Callback options ---
 
 // WithCodeFormatter sets a callback that receives raw code and a language hint,

--- a/options_test.go
+++ b/options_test.go
@@ -477,6 +477,36 @@ func TestWithCodeLineNumberSep(t *testing.T) {
 	}
 }
 
+func TestWithCodeLineNumberOffset(t *testing.T) {
+	t.Run("sets custom offset", func(t *testing.T) {
+		ty := New(WithCodeLineNumberOffset(42))
+		if ty.theme.CodeLineNumberOffset != 42 {
+			t.Errorf("expected offset 42, got %d", ty.theme.CodeLineNumberOffset)
+		}
+	})
+
+	t.Run("default is 1", func(t *testing.T) {
+		ty := New()
+		if ty.theme.CodeLineNumberOffset != 1 {
+			t.Errorf("expected default offset 1, got %d", ty.theme.CodeLineNumberOffset)
+		}
+	})
+
+	t.Run("ignores zero", func(t *testing.T) {
+		ty := New(WithCodeLineNumberOffset(0))
+		if ty.theme.CodeLineNumberOffset != 1 {
+			t.Errorf("expected offset 1 after setting 0, got %d", ty.theme.CodeLineNumberOffset)
+		}
+	})
+
+	t.Run("ignores negative", func(t *testing.T) {
+		ty := New(WithCodeLineNumberOffset(-5))
+		if ty.theme.CodeLineNumberOffset != 1 {
+			t.Errorf("expected offset 1 after setting -5, got %d", ty.theme.CodeLineNumberOffset)
+		}
+	})
+}
+
 func TestWithSemanticBadgeTagStyles(t *testing.T) {
 	style := lipgloss.NewStyle().Bold(true)
 

--- a/palette.go
+++ b/palette.go
@@ -204,8 +204,9 @@ func ThemeFromPalette(p ColorPalette) Theme {
 		FootnoteDividerChar:  DefaultFootnoteDividerChar,
 		FootnoteDividerWidth: DefaultFootnoteDividerWidth,
 
-		CodeLineNumber:    lipgloss.NewStyle().Foreground(p.Muted).Background(p.Base),
-		CodeLineNumberSep: DefaultCodeLineNumberSep,
+		CodeLineNumber:       lipgloss.NewStyle().Foreground(p.Muted).Background(p.Base),
+		CodeLineNumberSep:    DefaultCodeLineNumberSep,
+		CodeLineNumberOffset: DefaultCodeLineNumberOffset,
 
 		TableHeader: lipgloss.NewStyle().
 			Bold(true).

--- a/theme.go
+++ b/theme.go
@@ -90,9 +90,10 @@ type Theme struct {
 	HeadingBarChar  string // left-bar prefix for H4-H6 (e.g. "▎")
 
 	// Code block line numbers
-	CodeLineNumber    lipgloss.Style // style for line number text
-	CodeLineNumberSep string         // separator between line number and code (e.g. "│")
-	ShowLineNumbers   bool           // whether to render line numbers in CodeBlock
+	CodeLineNumber       lipgloss.Style // style for line number text
+	CodeLineNumberSep    string         // separator between line number and code (e.g. "│")
+	ShowLineNumbers      bool           // whether to render line numbers in CodeBlock
+	CodeLineNumberOffset int            // starting line number for code blocks (default 1)
 
 	// Configurable tokens
 	BulletChar           string   // character used for unordered list bullets
@@ -209,6 +210,7 @@ const (
 
 	DefaultAlertBar             = "│"
 	DefaultCodeLineNumberSep    = "│"
+	DefaultCodeLineNumberOffset = 1
 	DefaultTableCellPad         = 1
 	DefaultInsPrefix            = "+"
 	DefaultDelPrefix            = "-"

--- a/themes_test.go
+++ b/themes_test.go
@@ -104,6 +104,9 @@ func assertThemeValid(t *testing.T, theme Theme) {
 		if theme.ShowLineNumbers {
 			t.Error("ShowLineNumbers should be false by default")
 		}
+		if theme.CodeLineNumberOffset != DefaultCodeLineNumberOffset {
+			t.Errorf("CodeLineNumberOffset: expected %d, got %d", DefaultCodeLineNumberOffset, theme.CodeLineNumberOffset)
+		}
 	})
 
 	t.Run("CodeFormatter is nil", func(t *testing.T) {

--- a/typography.go
+++ b/typography.go
@@ -212,14 +212,16 @@ func (t *Typography) CodeBlock(text string, lang ...string) string {
 // Render calls that break background propagation.
 func (t *Typography) codeBlockWithLineNumbers(content string) string {
 	lines := strings.Split(content, "\n")
-	width := len(fmt.Sprintf("%d", len(lines)))
+	offset := t.theme.CodeLineNumberOffset
+	lastNum := offset + len(lines) - 1
+	width := len(fmt.Sprintf("%d", lastNum))
 
 	bg := t.theme.CodeBlock.GetBackground()
 
 	// Build the gutter column: right-aligned numbers + separator.
 	gutter := make([]string, len(lines))
 	for i := range lines {
-		gutter[i] = fmt.Sprintf("%*d", width, i+1) + t.theme.CodeLineNumberSep
+		gutter[i] = fmt.Sprintf("%*d", width, offset+i) + t.theme.CodeLineNumberSep
 	}
 	gutterStyle := t.theme.CodeLineNumber.
 		Background(bg).

--- a/typography_test.go
+++ b/typography_test.go
@@ -540,6 +540,40 @@ func TestCodeBlockLineNumbers(t *testing.T) {
 			t.Errorf("expected single line number, got %q", result)
 		}
 	})
+
+}
+
+func TestCodeBlockLineNumberOffset(t *testing.T) {
+	t.Run("custom offset", func(t *testing.T) {
+		ty := New(WithCodeLineNumbers(true), WithCodeLineNumberOffset(42))
+		result := stripANSI(ty.CodeBlock("aaa\nbbb\nccc"))
+		if !strings.Contains(result, "42"+DefaultCodeLineNumberSep+" aaa") {
+			t.Errorf("expected line 42, got %q", result)
+		}
+		if !strings.Contains(result, "44"+DefaultCodeLineNumberSep+" ccc") {
+			t.Errorf("expected line 44, got %q", result)
+		}
+	})
+
+	t.Run("offset widens gutter", func(t *testing.T) {
+		ty := New(WithCodeLineNumbers(true), WithCodeLineNumberOffset(99))
+		result := stripANSI(ty.CodeBlock("x\ny\nz"))
+		// Lines 99, 100, 101 -> width 3 -> "99" should be padded to " 99"
+		if !strings.Contains(result, " 99"+DefaultCodeLineNumberSep) {
+			t.Errorf("expected padded line 99, got %q", result)
+		}
+		if !strings.Contains(result, "101"+DefaultCodeLineNumberSep) {
+			t.Errorf("expected line 101, got %q", result)
+		}
+	})
+
+	t.Run("offset ignored when line numbers disabled", func(t *testing.T) {
+		ty := New(WithCodeLineNumberOffset(10))
+		result := stripANSI(ty.CodeBlock("hello"))
+		if strings.Contains(result, "10") {
+			t.Errorf("offset should have no effect when line numbers disabled, got %q", result)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `WithCodeLineNumberOffset(n)` option to set a custom starting line number for code blocks
- Default offset is 1 (no behavior change); offset only applies when `ShowLineNumbers` is true
- Values less than 1 are silently ignored, matching existing guard patterns

## Related Issue

- #46