### PR TITLE
feat: add per-call options for KVGroup rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ fmt.Println(ty.H4("Subsection"))
 | `DD(text)`                            | Definition description (standalone)                                           |
 | `KV(key, value)`                      | Key-value pair rendered as `key: value` with independent styling              |
 | `KVGroup(pairs)`                      | Aligned key-value list from `[][2]string` pairs; keys are right-padded        |
+| `KVGroupWithOpts(pairs, opts...)`     | Like `KVGroup` with per-call options for separator, styling, and indentation  |
 | `Address(text)`                       | Contact/author block; renders multi-line text in a distinctive italic style   |
 | `AddressCard(text)`                   | Bordered card variant of `Address` with rounded border                        |
 | `FootnoteRef(n)`                      | Inline footnote reference marker, e.g. `[1]`                                  |
@@ -171,6 +172,12 @@ fmt.Println(ty.KVGroup([][2]string{
     {"Role", "Admin"},
     {"Status", "Active"},
 }))
+
+// KVGroup with per-call options: no separator, pre-styled keys, indented
+fmt.Println(ty.KVGroupWithOpts([][2]string{
+    {ty.Var("--output"), "Output destination"},
+    {ty.Var("--verbose"), "Enable verbose output"},
+}, herald.WithKVGroupSeparator(""), herald.WithKVRawKeys(true), herald.WithKVIndent(2)))
 
 fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))
 
@@ -788,9 +795,20 @@ ty := herald.New(
 
 #### Key-value tokens
 
+**Theme-level** (set via `herald.New()`):
+
 | Option               | Default | Description                                       |
 | -------------------- | ------- | ------------------------------------------------- |
 | `WithKVSeparator(c)` | `:`     | Separator between key and value in `KV`/`KVGroup` |
+
+**Per-call** (passed to `KVGroupWithOpts`):
+
+| Option                    | Default       | Description                                                |
+| ------------------------- | ------------- | ---------------------------------------------------------- |
+| `WithKVGroupSeparator(s)` | theme default | Override separator for this call (empty string = no colon) |
+| `WithKVRawKeys(bool)`     | `false`       | Skip applying KVKey style (keys are pre-styled)            |
+| `WithKVRawValues(bool)`   | `false`       | Skip applying KVValue style (values are pre-styled)        |
+| `WithKVIndent(n)`         | `0`           | Prepend n spaces of indentation to each line               |
 
 #### Table tokens
 

--- a/examples/000_default-theme/main.go
+++ b/examples/000_default-theme/main.go
@@ -131,6 +131,15 @@ func main() {
 	}))
 	fmt.Println()
 
+	// KVGroupWithOpts: no separator, pre-styled keys, indented
+	fmt.Println(ty.H3("KVGroupWithOpts"))
+	fmt.Println(ty.KVGroupWithOpts([][2]string{
+		{ty.Var("--output") + " " + ty.Small("string"), "Output destination " + ty.Small("(default: stdout)")},
+		{ty.Var("--verbose"), "Enable verbose output"},
+		{ty.Var("--port") + " " + ty.Small("int"), "Port number " + ty.Small("(default: 8080)")},
+	}, herald.WithKVGroupSeparator(""), herald.WithKVRawKeys(true), herald.WithKVRawValues(true), herald.WithKVIndent(2)))
+	fmt.Println()
+
 	// Address
 	fmt.Println(ty.H3("Address"))
 	fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))

--- a/examples/demos/blocks/main.go
+++ b/examples/demos/blocks/main.go
@@ -51,6 +51,13 @@ func main() {
 	}))
 	fmt.Println()
 
+	// KVGroupWithOpts
+	fmt.Println(ty.KVGroupWithOpts([][2]string{
+		{ty.Var("--output") + " " + ty.Small("string"), "Output destination"},
+		{ty.Var("--verbose"), "Enable verbose output"},
+	}, herald.WithKVGroupSeparator(""), herald.WithKVRawKeys(true), herald.WithKVRawValues(true), herald.WithKVIndent(2)))
+	fmt.Println()
+
 	fmt.Println(ty.Address("Jane Doe\njane@example.com\nSan Francisco, CA"))
 	fmt.Println()
 	fmt.Println(ty.AddressCard("Jane Doe\njane@example.com\nSan Francisco, CA"))

--- a/kv_options.go
+++ b/kv_options.go
@@ -1,0 +1,34 @@
+package herald
+
+// KVOption is a functional option for KVGroupWithOpts.
+type KVOption func(*kvConfig)
+
+type kvConfig struct {
+	separator *string // override theme KVSeparator (nil = use theme default)
+	rawKeys   bool    // skip applying KVKey style (keys are pre-styled)
+	rawValues bool    // skip applying KVValue style (values are pre-styled)
+	indent    int     // left indent in spaces (0 = no indent)
+}
+
+// WithKVGroupSeparator overrides the separator between key and value for this
+// call only. Pass an empty string to suppress the separator entirely.
+func WithKVGroupSeparator(s string) KVOption {
+	return func(cfg *kvConfig) { cfg.separator = &s }
+}
+
+// WithKVRawKeys skips applying the theme's KVKey style to keys. Use this
+// when keys are already styled (e.g. via Var, Bold, or other herald methods).
+func WithKVRawKeys(raw bool) KVOption {
+	return func(cfg *kvConfig) { cfg.rawKeys = raw }
+}
+
+// WithKVRawValues skips applying the theme's KVValue style to values. Use
+// this when values are already styled or contain mixed styled content.
+func WithKVRawValues(raw bool) KVOption {
+	return func(cfg *kvConfig) { cfg.rawValues = raw }
+}
+
+// WithKVIndent prepends each line with n spaces of indentation.
+func WithKVIndent(n int) KVOption {
+	return func(cfg *kvConfig) { cfg.indent = n }
+}

--- a/typography.go
+++ b/typography.go
@@ -872,9 +872,31 @@ func (t *Typography) KV(key, value string) string {
 // values align vertically. Each pair is a two-element array [key, value].
 // Returns an empty string for empty input.
 func (t *Typography) KVGroup(pairs [][2]string) string {
+	return t.KVGroupWithOpts(pairs)
+}
+
+// KVGroupWithOpts renders key-value pairs like KVGroup but accepts functional
+// options to customise the separator, styling, and indentation per call.
+func (t *Typography) KVGroupWithOpts(pairs [][2]string, opts ...KVOption) string {
 	if len(pairs) == 0 {
 		return ""
 	}
+
+	cfg := &kvConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	sep := t.theme.KVSeparator
+	if cfg.separator != nil {
+		sep = *cfg.separator
+	}
+
+	indent := ""
+	if cfg.indent > 0 {
+		indent = strings.Repeat(" ", cfg.indent)
+	}
+
 	// Find max key width for alignment.
 	maxKeyWidth := 0
 	for _, pair := range pairs {
@@ -882,11 +904,23 @@ func (t *Typography) KVGroup(pairs [][2]string) string {
 			maxKeyWidth = w
 		}
 	}
+
 	lines := make([]string, len(pairs))
 	for i, pair := range pairs {
 		keyWidth := lipgloss.Width(pair[0])
 		padding := strings.Repeat(" ", maxKeyWidth-keyWidth)
-		lines[i] = t.theme.KVKey.Render(pair[0]+padding+t.theme.KVSeparator) + " " + t.theme.KVValue.Render(pair[1])
+
+		key := pair[0] + padding + sep
+		if !cfg.rawKeys {
+			key = t.theme.KVKey.Render(key)
+		}
+
+		val := pair[1]
+		if !cfg.rawValues {
+			val = t.theme.KVValue.Render(val)
+		}
+
+		lines[i] = indent + key + " " + val
 	}
 	return strings.Join(lines, "\n")
 }

--- a/typography_test.go
+++ b/typography_test.go
@@ -1445,6 +1445,131 @@ func TestKVGroup(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// KVGroupWithOpts
+// ---------------------------------------------------------------------------
+
+func kvTestPairs() [][2]string {
+	return [][2]string{
+		{"Name", "Alice"},
+		{"Location", "Wonderland"},
+	}
+}
+
+func TestKVGroupWithOptsNoOptions(t *testing.T) {
+	ty := newTestTypography()
+	pairs := kvTestPairs()
+	got := stripANSI(ty.KVGroupWithOpts(pairs))
+	want := stripANSI(ty.KVGroup(pairs))
+	if got != want {
+		t.Errorf("KVGroupWithOpts() = %q, want %q", got, want)
+	}
+}
+
+func TestKVGroupWithOptsEmpty(t *testing.T) {
+	ty := newTestTypography()
+	got := ty.KVGroupWithOpts(nil)
+	if got != "" {
+		t.Errorf("KVGroupWithOpts(nil) = %q, want empty", got)
+	}
+}
+
+func TestKVGroupWithOptsCustomSeparator(t *testing.T) {
+	ty := newTestTypography()
+	got := stripANSI(ty.KVGroupWithOpts(kvTestPairs(), WithKVGroupSeparator(" =")))
+	for i, line := range strings.Split(got, "\n") {
+		if !strings.Contains(line, " = ") {
+			t.Errorf("line %d should contain ' = ': %q", i, line)
+		}
+	}
+}
+
+func TestKVGroupWithOptsEmptySeparator(t *testing.T) {
+	ty := newTestTypography()
+	got := stripANSI(ty.KVGroupWithOpts(kvTestPairs(), WithKVGroupSeparator("")))
+	for i, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, ":") {
+			t.Errorf("line %d should not contain ':': %q", i, line)
+		}
+	}
+}
+
+func TestKVGroupWithOptsRawKeys(t *testing.T) {
+	ty := newTestTypography()
+	styled := [][2]string{
+		{ty.Bold("Name"), "Alice"},
+		{ty.Bold("Location"), "Wonderland"},
+	}
+	got := ty.KVGroupWithOpts(styled, WithKVRawKeys(true))
+	if got == "" {
+		t.Error("KVGroupWithOpts raw keys returned empty")
+	}
+}
+
+func TestKVGroupWithOptsRawValues(t *testing.T) {
+	ty := newTestTypography()
+	styled := [][2]string{
+		{"Name", ty.Italic("Alice")},
+	}
+	got := ty.KVGroupWithOpts(styled, WithKVRawValues(true))
+	if got == "" {
+		t.Error("KVGroupWithOpts raw values returned empty")
+	}
+}
+
+func TestKVGroupWithOptsIndent(t *testing.T) {
+	ty := newTestTypography()
+	got := stripANSI(ty.KVGroupWithOpts(kvTestPairs(), WithKVIndent(4)))
+	for i, line := range strings.Split(got, "\n") {
+		if !strings.HasPrefix(line, "    ") {
+			t.Errorf("line %d should have 4-space indent: %q", i, line)
+		}
+	}
+}
+
+func TestKVGroupWithOptsCombined(t *testing.T) {
+	ty := newTestTypography()
+	styled := [][2]string{
+		{ty.Var("--output"), "Output destination"},
+		{ty.Var("--verbose"), "Enable verbose output"},
+	}
+	got := stripANSI(ty.KVGroupWithOpts(styled,
+		WithKVGroupSeparator(""),
+		WithKVRawKeys(true),
+		WithKVIndent(2),
+	))
+	lines := strings.Split(got, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "  ") {
+			t.Errorf("line %d should have 2-space indent: %q", i, line)
+		}
+		if strings.Contains(line, ":") {
+			t.Errorf("line %d should not contain ':': %q", i, line)
+		}
+	}
+}
+
+func TestKVGroupWithOptsAlignment(t *testing.T) {
+	ty := newTestTypography()
+	styled := [][2]string{
+		{ty.Bold("A"), "short"},
+		{ty.Bold("Longer"), "also short"},
+	}
+	got := stripANSI(ty.KVGroupWithOpts(styled, WithKVRawKeys(true), WithKVGroupSeparator("")))
+	lines := strings.Split(got, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	idx1 := strings.Index(lines[0], "short")
+	idx2 := strings.Index(lines[1], "also short")
+	if idx1 != idx2 {
+		t.Errorf("values not aligned: %q at %d, %q at %d", lines[0], idx1, lines[1], idx2)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Compose
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
  ## Summary

Add `KVGroupWithOpts` method with functional options for per-call control over separator, key/value styling, and indentation:

- `WithKVGroupSeparator(s)` overrides the theme separator (empty string suppresses the colon)
- `WithKVRawKeys(true)` / `WithKVRawValues(true)` skip theme styling when keys or values are pre-styled
- `WithKVIndent(n)` prepends n spaces to each line
- `KVGroup` now delegates to `KVGroupWithOpts` with no behavior change