### PR TITLE
feat: add BR and Section methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
   <b><a href="#examples">Examples</a></b>
 </p>
 
-herald maps familiar HTML elements (H1-H6, P, Blockquote, UL, OL, Code, HR, Tables, Alerts, and inline styles) to styled terminal output, built on [lipgloss v2](https://github.com/charmbracelet/lipgloss).
+herald maps familiar HTML elements (H1-H6, P, Blockquote, UL, OL, Code, HR, BR, Tables, Alerts, and inline styles) to styled terminal output, built on [lipgloss v2](https://github.com/charmbracelet/lipgloss).
 
 It ships with a Rose Pine-inspired default theme, built-in themes matching the Charm ecosystem (Dracula, Catppuccin, Base16, Charm), and full style customization via functional options and ColorPalette.
 
@@ -146,6 +146,8 @@ fmt.Println(ty.H4("Subsection"))
 | `Fieldset(legend, content, width...)` | Bordered box with legend embedded in top border; auto-width or explicit       |
 | `Figure(content, caption)`            | Content with styled caption below                                             |
 | `FigureTop(content, caption)`         | Content with styled caption above                                             |
+| `BR()`                                | Line break, analogous to `<br/>`                                              |
+| `Section(blocks...)`                  | Joins blocks with single newlines; keeps a heading tight against its content  |
 | `Compose(blocks...)`                  | Joins pre-rendered blocks with double newlines; empty blocks are skipped      |
 
 ```go
@@ -205,6 +207,24 @@ fmt.Println(ty.FigureTop(ty.Table([][]string{
 │ Port:  8080                          │
 │ TLS:   enabled                       │
 ╰──────────────────────────────────────╯
+```
+
+```go
+// BR inserts a line break
+fmt.Println(ty.P("Line one" + ty.BR() + "Line two"))
+
+// Section groups blocks with single newlines instead of double
+fmt.Println(ty.Compose(
+    ty.H2("Shopping List"),
+    ty.Section(
+        ty.H4("Fruits"),
+        ty.UL("Apples", "Bananas", "Cherries"),
+    ),
+    ty.Section(
+        ty.H4("Vegetables"),
+        ty.UL("Carrots", "Spinach"),
+    ),
+))
 ```
 
 ### Inline styles
@@ -576,6 +596,24 @@ fmt.Println(ty.Compose(
         " key indicators.",
     ),
     ty.FootnoteSection([]string{"A Go library for TUI typography"}),
+))
+```
+
+### Tight heading-body groups
+
+`Compose` inserts a blank line (`\n\n`) between every block. When a heading (e.g. H4) already has `MarginBottom`, this produces unwanted triple spacing. `Section` solves this by joining its blocks with a single newline, and the resulting group becomes one block to `Compose`:
+
+```go
+fmt.Println(ty.Compose(
+    ty.H2("Release Notes"),
+    ty.Section(
+        ty.H4("Bug Fixes"),
+        ty.UL("Fixed crash on empty input", "Resolved race condition"),
+    ),
+    ty.Section(
+        ty.H4("Features"),
+        ty.UL("Added Section method", "Added BR method"),
+    ),
 ))
 ```
 
@@ -1160,6 +1198,7 @@ Runnable examples are in the [`examples/`](examples/) directory:
 | [003_table](examples/003_table/)                                                       | Table rendering: bordered, minimal, alignment, striped rows, captions, and footer |
 | [004_semantic-badges](examples/004_semantic-badges/)                                   | Semantic badge and tag methods with default and custom `SemanticPalette`          |
 | [005_compose](examples/005_compose/)                                                   | Compose multiple rendered blocks into a single output                             |
+| [006_section](examples/006_section/)                                                   | Section groups heading + content tightly; BR for line breaks                      |
 | [100_custom-options](examples/100_custom-options/)                                     | Override styles, decoration chars, and tokens via functional options              |
 | [101_custom-palette](examples/101_custom-palette/)                                     | Custom adaptive theme from 9 colors using `ColorPalette` and `LightDark`          |
 | [102_builtin-themes](examples/102_builtin-themes/)                                     | Built-in themes (Dracula, Catppuccin, Base16, Charm) matching huh                 |

--- a/examples/006_section/main.go
+++ b/examples/006_section/main.go
@@ -1,0 +1,34 @@
+// Section groups a heading with its content so Compose does not insert
+// an extra blank line between them.
+// Run: go run ./examples/006_section/
+package main
+
+import (
+	"fmt"
+
+	"github.com/indaco/herald"
+)
+
+func main() {
+	ty := herald.New()
+
+	// Without Section, Compose would insert a double newline between
+	// each H4 and its list, creating unwanted vertical space.
+	// Section joins them with a single newline instead.
+	page := ty.Compose(
+		ty.H2("Shopping List"),
+		ty.Section(
+			ty.H4("Fruits"),
+			ty.UL("Apples", "Bananas", "Cherries"),
+		),
+		ty.Section(
+			ty.H4("Vegetables"),
+			ty.UL("Carrots", "Spinach", "Peppers"),
+		),
+		ty.HR(),
+		ty.P("BR inserts a simple line break:"),
+		ty.P("Line one"+ty.BR()+"Line two"),
+	)
+
+	fmt.Println(page)
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ Some examples live in the root module and can be run directly with `go run`. Oth
 | [003_table](003_table/)                     | Table rendering: bordered, minimal, alignment, striped rows, captions, and footer | `go run ./examples/003_table/`           |
 | [004_semantic-badges](004_semantic-badges/) | Semantic badges and tags with default and custom palettes                         | `go run ./examples/004_semantic-badges/` |
 | [005_compose](005_compose/)                 | Compose multiple rendered blocks into a single output                             | `go run ./examples/005_compose/`         |
+| [006_section](006_section/)                 | Section groups heading + content tightly; BR for line breaks                      | `go run ./examples/006_section/`         |
 
 ### Customization (`1xx`)
 

--- a/typography.go
+++ b/typography.go
@@ -246,6 +246,26 @@ func (t *Typography) codeBlockWithLineNumbers(content string) string {
 	)
 }
 
+// BR returns a line break, analogous to HTML <br/>.
+func (t *Typography) BR() string {
+	return "\n"
+}
+
+// Section joins blocks with a single newline (no blank line between them),
+// unlike Compose which uses double newlines. Use this when a heading should
+// sit tight against its content, avoiding the extra blank line that Compose
+// would insert between a heading with MarginBottom and the following block.
+func (t *Typography) Section(blocks ...string) string {
+	non := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		trimmed := strings.TrimRight(b, "\n")
+		if trimmed != "" {
+			non = append(non, trimmed)
+		}
+	}
+	return strings.Join(non, "\n")
+}
+
 // HR renders a horizontal rule.
 func (t *Typography) HR() string {
 	line := strings.Repeat(t.theme.HRChar, t.theme.HRWidth)

--- a/typography_test.go
+++ b/typography_test.go
@@ -1573,6 +1573,93 @@ func TestKVGroupWithOptsAlignment(t *testing.T) {
 // Compose
 // ---------------------------------------------------------------------------
 
+func TestBR(t *testing.T) {
+	ty := newTestTypography()
+	result := ty.BR()
+	if result != "\n" {
+		t.Errorf("BR = %q, want %q", result, "\n")
+	}
+}
+
+func TestSection(t *testing.T) {
+	ty := newTestTypography()
+
+	t.Run("joins blocks with single newline", func(t *testing.T) {
+		result := ty.Section("aaa", "bbb", "ccc")
+		if result != "aaa\nbbb\nccc" {
+			t.Errorf("Section = %q, want %q", result, "aaa\nbbb\nccc")
+		}
+	})
+
+	t.Run("skips empty blocks", func(t *testing.T) {
+		result := ty.Section("aaa", "", "bbb", "", "")
+		if result != "aaa\nbbb" {
+			t.Errorf("Section with empties = %q, want %q", result, "aaa\nbbb")
+		}
+	})
+
+	t.Run("single block", func(t *testing.T) {
+		result := ty.Section("only")
+		if result != "only" {
+			t.Errorf("Section single = %q, want %q", result, "only")
+		}
+	})
+
+	t.Run("no blocks", func(t *testing.T) {
+		result := ty.Section()
+		if result != "" {
+			t.Errorf("Section empty = %q, want empty", result)
+		}
+	})
+
+	t.Run("all empty blocks", func(t *testing.T) {
+		result := ty.Section("", "", "")
+		if result != "" {
+			t.Errorf("Section all empty = %q, want empty", result)
+		}
+	})
+
+	t.Run("strips trailing newlines", func(t *testing.T) {
+		result := ty.Section("aaa\n\n", "bbb\n")
+		if result != "aaa\nbbb" {
+			t.Errorf("Section trailing newlines = %q, want %q", result, "aaa\nbbb")
+		}
+	})
+
+	t.Run("with rendered heading and list", func(t *testing.T) {
+		result := ty.Section(
+			ty.H4("Fruits"),
+			ty.UL("Apples", "Bananas"),
+		)
+		plain := stripANSI(result)
+		if !strings.Contains(plain, "Fruits") {
+			t.Error("Section: missing heading")
+		}
+		if !strings.Contains(plain, "Apples") {
+			t.Error("Section: missing list item")
+		}
+		// Section should NOT have double-newline separators
+		if strings.Contains(result, "\n\n") {
+			t.Error("Section: should not contain double-newline separators")
+		}
+	})
+
+	t.Run("inside Compose", func(t *testing.T) {
+		result := ty.Compose(
+			ty.Section(ty.H4("Fruits"), ty.UL("Apples", "Bananas")),
+			ty.Section(ty.H4("Colors"), ty.UL("Red", "Blue")),
+		)
+		plain := stripANSI(result)
+		if !strings.Contains(plain, "Fruits") || !strings.Contains(plain, "Colors") {
+			t.Error("Section inside Compose: missing headings")
+		}
+		// Compose should insert double newline between sections
+		if strings.Count(result, "\n\n") < 1 {
+			t.Error("Section inside Compose: expected double-newline between sections")
+		}
+	})
+}
+
 func TestCompose(t *testing.T) {
 	ty := newTestTypography()
 


### PR DESCRIPTION
## Summary

This PR adds:

- `BR()` method (line break, `<br/>` equivalent)
- `Section(blocks...)` method (single-newline join, tight heading-body grouping)

 ## Motivation

`Compose` joins blocks with `\n\n`, but heading elements already have `MarginBottom(1)` which adds another `\n` - producing unwanted triple spacing.

`Section` solves this by collapsing heading + content into a single block before `Compose` sees it.