### PR TITLE
ci: add dependabot config for GitHub actions and upgrade codecov action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: 'gomod'
-    directory: '/'
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: 'monthly'
+      interval: "monthly"
     labels:
-      - 'deps'
+      - "deps"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "ci"
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,6 +47,6 @@ jobs:
         run: just test-coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

-  Add dependabot configuration to keep GitHub actions up to date
- Upgrade codecov action to v6